### PR TITLE
feat: align RF-DETR 1.9.3 and 1.9.4 inference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ The `executorch` variant builds the ExecuTorch runtime from source into `/opt/ex
 - Strict warnings (CI): `-DWERROR=ON` at configure time
 
 ## Spec Sync
+- Mandatory: `git fetch` and check the branch against its upstream **before starting any work** — not just before pushing. A stale local branch hides the rules you are supposed to follow: on 2026-08-24 an alignment pass was written against a `develop` four commits behind `origin/develop`, missing an already-completed 1.9.2 alignment, the `specs/` tree, and the `rfdetr-alignment` skill that governs the task. If the branch is behind, integrate or at least read what landed, then re-read `AGENTS.md`, `.claude/skills/`, and `specs/` before planning.
 - Mandatory: before acting on any release, version-alignment, or dependency-sync request, read `AGENTS.md`, `README.md`, and `CHANGELOG.md`, then verify the named release against the official upstream project. Never assume that an upstream version is a local Git tag or infer the required scope from the version string alone; inspect the repository documentation and upstream release notes/diff first.
 - A change to `specs/mission.md` or `specs/tech-stack.md` must propagate in the **same commit** to `README.md`, `AGENTS.md`, and any open spec under `specs/features/`. The constitution and what it describes never diverge across commits.
 - Mandatory for every release or dependency-facing patch: update `README.md` in the same change when code, build options, backend versions, Docker images, or Python export packages change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,83 @@ paths implemented by this repository.
 
 ---
 
+### RF-DETR 1.9.3 / 1.9.4 alignment
+
+**Upstream releases**: [1.9.3](https://github.com/roboflow/rf-detr/releases/tag/1.9.3),
+[1.9.4](https://github.com/roboflow/rf-detr/releases/tag/1.9.4)
+
+Continues from the 1.9.2 alignment above, which correctly found nothing for C++ to do.
+1.9.3 and 1.9.4 are different: two changes land on the decode path, and both were wrong
+here in the same way they were wrong upstream:
+
+1. **Detections were being dropped.** Class scores are independent sigmoids, so one
+   query can score above threshold on several classes at once. The detection and
+   keypoint paths took a per-query `argmax` and kept only the strongest, exactly the bug
+   1.9.3 (PR #1320) fixed in upstream's own ONNX/TFLite decoders. All three heads now
+   rank the flattened *(query, class)* grid the way `PostProcess._select_topk` does.
+2. **The background logit slot was hardcoded.** 1.9.4 (PR #1397) made it an explicit
+   argument, because the assumption is checkpoint-dependent and a wrong guess shifts
+   every reported label. Exposed here as `Config::background_class_id` and
+   `--background-class-id`.
+
+Ordering also became contractual: descending score, then ascending flattened query/class
+index. That fell out of 1.9.3 replacing `torch.topk` with a stable `argsort`.
+
+#### Fixed
+
+| File | Change |
+|------|--------|
+| `src/rfdetr_inference.cpp` | `postprocess_outputs()` and `postprocess_keypoint_outputs()` rank the flattened *(query, class)* grid instead of taking a per-query `argmax`, so a query above threshold on more than one class now yields one detection per class rather than only its strongest. Both also honour `max_detections` as the ranking cap, which the detection path previously ignored entirely. |
+| `src/rfdetr_inference.cpp` | The segmentation path excludes the background column **before** ranking. It used to rank every column and skip background candidates afterwards, so background pairs consumed slots of the `max_detections` cap and could push real detections out of a crowded frame. |
+| `src/rfdetr_inference.cpp`, `src/gpu/rfdetr_postprocess.cu` | Kept scores are now tested with `score > threshold` rather than `!(score <= threshold)`. A NaN score fails the first and passes the second, so a malformed logit used to be emitted as a detection with a NaN confidence. |
+| `src/processing_utils.cpp` | The segmentation ranking comparator was `all_scores[i1] > all_scores[i2]`, which is not a strict weak ordering when any score is NaN — undefined behaviour in `std::partial_sort`. The shared `select_topk_multiclass()` substitutes `+inf` for NaN before comparing, which both restores the ordering and reproduces torch's NaN-ranks-first behaviour. |
+
+#### Added
+
+| File | Change |
+|------|--------|
+| `src/processing_utils.{hpp,cpp}` | `resolve_background_slot()`, `foreground_class_count()`, `slot_for_foreground_column()`, `build_foreground_scores()`, `select_topk_multiclass()` — C++ mirrors of upstream's `export/_class_layout.py` (1.9.4) and `export/_topk.py` (1.9.3). One selection rule now serves detection, segmentation, keypoint, and the CUDA kernels. |
+| `src/rfdetr_inference.hpp` | `Config::background_class_id` (`std::optional<int>`, default `0`): the exported logit slot holding background, excluded before ranking. Negative values count from the end, `std::nullopt` keeps every slot — upstream's `background_class_id` semantics. |
+| `src/main.cpp` | `--background-class-id <n\|none>`. |
+| `tests/unit/test_rfdetr_inference.cpp` | Ten tests: multi-label selection (a query yielding two classes), descending-score output order, the ascending-flat-index tie rule, `max_detections` capping candidates before thresholding, NaN dropped rather than kept, `background_class_id` as `none` / negative / out-of-range, negative `max_detections` rejected at construction, and the segmentation path sharing the same selection. |
+
+#### Changed
+
+| File | Change |
+|------|--------|
+| `src/rfdetr_inference.cpp` | Construction rejects a negative `max_detections` with `std::invalid_argument`, mirroring 1.9.3 making `PostProcess(num_select=<negative>)` a construction-time `ValueError` instead of a silently accepted no-op. |
+| `src/gpu/rfdetr_postprocess.{hpp,cu}` | `SegPostprocessParams::background_slot`; `decode_scores` compacts the foreground columns before the sort so the GPU ranks the same candidate set as the CPU. CUB's radix sort is stable, so ties already came out in ascending flattened index order — the CPU rule is now written down beside it. |
+| `deploy/requirements.txt`, `deploy/export_executorch.py` | `rfdetr` 1.9.2 → 1.9.4. |
+| `specs/mission.md`, `specs/tech-stack.md` | Version statement and export-tooling pin row to 1.9.4, propagated in this same commit per the Spec Sync rule. |
+| `specs/features/2026-08-25-rfdetr-1.9.4-alignment/` | Spec triple for this pass: the skill's Step 1 classification table, the decisions behind the `background_class_id` default and the pre-ranking exclusion, and a validation sheet recording what was and was not verified. Written after the implementation rather than before it — the reason is in its `requirements.md` → Context, and the `AGENTS.md` rule below is the fix. |
+| `AGENTS.md` | New mandatory rule: `git fetch` and check against upstream **before starting work**, not only before pushing. This alignment was written against a `develop` four commits stale, so it missed the completed 1.9.2 pass, the `specs/` tree, and the `rfdetr-alignment` skill governing the task — and then conflicted in six files. |
+| `README.md`, `docs/export.md` | Version statements to rfdetr 1.9.4. New "How detections are selected" README section (multi-label ranking, the cap-then-threshold order, the tie rule) and a `--background-class-id` entry explaining when the default is wrong. `docs/export.md` notes what 1.9.2–1.9.4 do and do not change for an exported model. |
+
+#### Why the class ids did not move
+
+Upstream's own decoder defaults to `background_class_id=-1` — background in the *final*
+logit slot — and 1.9.4's release notes say plainly that this mis-decodes the official
+pretrained COCO weights, whose final slot holds real category 90 (`toothbrush`). This
+project has always used the other convention: slot 0 is background, slot *n* is COCO
+category *n*, and `data/coco-labels-91.txt` is indexed by COCO id so slot *n* reads
+entry *n*. That is upstream's `background_class_id=0` case, so the default stays `0` and
+decoded labels are unchanged. The flag exists for checkpoints that are laid out
+differently — a fine-tuned model with contiguous 0-based ids wants `none`.
+
+#### Not mirrored
+
+The rest of 1.9.3–1.9.4 does not reach an exported model: evaluation-sweep and matcher
+performance, `metrics.csv` history across resumes, `BestModelCallback` scoring the
+Lightning sanity check as a real epoch, EMA epoch-boundary double counting, YOLO
+test-split resolution, AdamW-aware auto-batch probing, keypoint flip-pair and
+Albumentations `TimeReverse`/`SquareSymmetry` augmentation fixes, non-square training
+resize, and the TFLite conversion fixes. One is worth knowing about anyway and is
+written up in `docs/export.md`: 1.9.3's `SegmentationHead.skip_blocks` fix is
+training-only — the export path already applied the projection, so no re-export is
+needed. (1.9.2's label-space change is covered in its own entry above.)
+
+---
+
 ### RF-DETR 1.9.1 alignment
 
 **Upstream release**: https://github.com/roboflow/rf-detr/releases/tag/1.9.1

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ one is compiled in via `-DUSE_OPENCV=ON/OFF`.
 - Replaces FFmpeg, SDL2, **and** stb entirely — none of those are required when OpenCV is enabled
 
 ### Python / Pip Packages (Export Tooling)
-- **RF-DETR export package**: `rfdetr[onnx]==1.9.2` from `deploy/requirements.txt`
-- **ExecuTorch export (optional)**: `rfdetr[executorch]==1.9.2` — only needed to produce `.pte` models for the ExecuTorch backend. Pin it: the extra constrains ExecuTorch only to `>=1.3,<2.0`. Check what pip actually installed (`pip show executorch`) and ensure it matches the C++ runtime this project pins to v1.4.0
-- **TensorRT export (optional)**: `rfdetr[tensorrt]==1.9.2` — provides `tensorrt` + `polygraphy` for in-process engine builds (1.9.0+); `pycuda` moved to the separate `rfdetr[tensorrt-bench]` extra
+- **RF-DETR export package**: `rfdetr[onnx]==1.9.4` from `deploy/requirements.txt`
+- **ExecuTorch export (optional)**: `rfdetr[executorch]==1.9.4` — only needed to produce `.pte` models for the ExecuTorch backend. Pin it: the extra constrains ExecuTorch only to `>=1.3,<2.0`. Check what pip actually installed (`pip show executorch`) and ensure it matches the C++ runtime this project pins to v1.4.0
+- **TensorRT export (optional)**: `rfdetr[tensorrt]==1.9.4` — provides `tensorrt` + `polygraphy` for in-process engine builds (1.9.0+); `pycuda` moved to the separate `rfdetr[tensorrt-bench]` extra
 - **Python**: 3.10+ (Python 3.11 virtual environment recommended)
 - **pre-commit**: Optional for local hooks; install with `pip install pre-commit`
 
@@ -89,7 +89,7 @@ one is compiled in via `-DUSE_OPENCV=ON/OFF`.
 - See [GPU Pipeline](#gpu-pipeline) for build and usage details
 #### ExecuTorch Backend (Optional)
 - **ExecuTorch**: Version v1.4.0, built with `EXECUTORCH_BUILD_KERNELS_OPTIMIZED=ON` — resolved from an install prefix via `-DEXECUTORCH_ROOTDIR`, otherwise built from source
-- **Model format**: `.pte`, exported by `rfdetr[executorch]` 1.9.0+ (1.9.1 exports require the optimized kernel set — see [Building the ExecuTorch install prefix](#building-the-executorch-install-prefix))
+- **Model format**: `.pte`, exported by `rfdetr[executorch]` 1.9.0+ (1.9.1+ exports require the optimized kernel set — see [Building the ExecuTorch install prefix](#building-the-executorch-install-prefix))
 - **Delegate**: XNNPACK (default) or portable CPU kernels, selected with `-DEXECUTORCH_DELEGATE`
 - **Platform**: Linux; CPU inference through the linked delegate
 - **Note**: The delegate linked here must match the one baked into the `.pte` at export time
@@ -106,7 +106,7 @@ This project supports both RF-DETR detection and segmentation models from Robofl
 
 2. **Download the ONNX Model**:
    - Follow instructions in the [export documentation](docs/export.md) to export models in ONNX format.
-   - **Tested with**: `rfdetr[onnx]==1.9.2` (Python 3.10+; 3.11 venv recommended)
+   - **Tested with**: `rfdetr[onnx]==1.9.4` (Python 3.10+; 3.11 venv recommended)
    - **Detection models**: Export with standard configuration (outputs: `dets`, `labels`)
    - **Segmentation models**: Export with segmentation configuration (outputs: `dets`, `labels`, `masks`)
    - **Keypoint models**: Export with keypoint configuration (outputs: `dets`, `labels`, `keypoints`)
@@ -378,7 +378,7 @@ cmake --build build --parallel
 
 #### Building the ExecuTorch install prefix
 
-ExecuTorch **v1.4.0** is the pinned C++ runtime. The `rfdetr[executorch]==1.9.2`
+ExecuTorch **v1.4.0** is the pinned C++ runtime. The `rfdetr[executorch]==1.9.4`
 extra allows ExecuTorch `>=1.3,<2.0` and does not guarantee that version; `.pte` schema
 compatibility across ExecuTorch versions is not guaranteed.
 
@@ -415,7 +415,7 @@ link against one C++ runtime.
 > `OFF`, and without it the prefix ships only `portable_ops_lib`, which registers
 > `aten::addmm.out` and `aten::mm.out` but no `aten::linear.out`. rfdetr 1.9.1 recombines
 > the `addmm` ops XNNPACK leaves un-delegated back into `aten.linear` (6 such calls in an
-> `RFDETRNano` export), so a `.pte` from 1.9.1 fails at load on a portable-only prefix.
+> `RFDETRNano` export), so a `.pte` from 1.9.1 or newer fails at load on a portable-only prefix.
 > The build links `optimized_native_cpu_ops_lib` when the prefix provides it — it is a
 > superset of the portable set — and falls back to `portable_ops_lib` with a CMake warning
 > when it does not. Exactly one op library is linked either way: each registers its kernels
@@ -583,8 +583,9 @@ The inference parameters can be overridden without recompiling:
 |------|---------|--------|
 | `--threshold <val>` | `0.5` | Confidence threshold for keeping a detection; must be in `[0, 1]` |
 | `--resolution <px>` | auto-detect | Model input resolution; omit to detect it from the model |
-| `--max-detections <n>` | `300` | Top-k cap on the number of predictions considered |
+| `--max-detections <n>` | `300` | Top-k cap on the number of query/class pairs ranked before thresholding (upstream's `num_select`) |
 | `--mask-threshold <val>` | `0.0` | Mask logit cutoff for binary mask generation (segmentation only); may be negative |
+| `--background-class-id <n\|none>` | `0` | Exported logit slot holding background, excluded before ranking; negative counts from the end, `none` keeps every slot |
 
 ```bash
 ./build/inference_app /path/to/model.onnx /path/to/image.jpg /path/to/coco-labels-91.txt \
@@ -597,6 +598,24 @@ The inference parameters can be overridden without recompiling:
 These flags work with all modes (`--segmentation`, `--keypoint`, video input, and `--display`). `--resolution`
 is only useful for models that accept an input size other than the one recorded in the model file — the
 auto-detected value is correct for a normally exported model.
+
+`--background-class-id` mirrors the argument rfdetr 1.9.4 added to its own ONNX/TFLite decoders. The default
+`0` matches the shipped RF-DETR exports, whose logit 0 is background and whose logit *n* is COCO category *n*
+— which is exactly how `data/coco-labels-91.txt` is indexed. Change it only for a checkpoint with a different
+class layout: `none` for one where every logit slot is a real class (a fine-tuned model with contiguous
+0-based ids), or `-1` for one whose background sits in the final slot. Getting it wrong shifts every reported
+label by one.
+
+#### How detections are selected
+
+RF-DETR scores classes with independent sigmoids rather than a softmax, so one query can legitimately clear
+the threshold on several classes at once. Postprocessing therefore ranks the flattened *(query, class)* grid
+and keeps the top `--max-detections` pairs **before** applying `--threshold`, which is what
+`PostProcess._select_topk` does upstream — a per-query argmax would silently drop every class but the
+strongest (the bug rfdetr 1.9.3 fixed in its own exported-model decoders). Results come back in
+descending-score order, with exact ties broken by ascending flattened query/class index, so a given model and
+image always produce the same ordering. Detection, segmentation, keypoint, and the CUDA postprocess kernels
+all share that rule.
 
 #### Using Pre-built TensorRT Engine
 
@@ -716,6 +735,7 @@ command line — see [Tuning Flags](#tuning-flags) — and the rest require edit
 | `resolution` | auto-detected from the model | `--resolution <px>` |
 | `max_detections` | `300` (top-k selection) | `--max-detections <n>` |
 | `mask_threshold` | `0.0` (binary mask generation) | `--mask-threshold <val>` |
+| `background_class_id` | `0` (background-first exports) | `--background-class-id <n\|none>` |
 | `gpu_preprocess` / `gpu_postprocess` | `false` | `--gpu-preprocess` / `--gpu-postprocess` |
 | `dali_pipeline_dir` | `data/dali` | `--dali-pipeline-dir <dir>` |
 | `gpu_device_id` | `0` | — (edit `src/main.cpp`) |
@@ -912,8 +932,8 @@ A single parametric `Dockerfile` builds the full **inference-backend × media-ba
 > or registry package), so the first build is slow — it clones ExecuTorch with recursive
 > submodules and installs a CPU-only `torch` wheel for the operator codegen. Pin a
 > different runtime with `--build-arg EXECUTORCH_VERSION=<tag>`; it defaults to `v1.4.0`
-> to match the exporter used by `rfdetr[executorch]==1.9.2`, and enables the optimized
-> kernel set that 1.9.1 `.pte` files need. The build applies the
+> to match the exporter used by `rfdetr[executorch]==1.9.4`, and enables the optimized
+> kernel set that 1.9.1+ `.pte` files need. The build applies the
 > upstream `extension_evalue_util` install fix automatically. ExecuTorch links
 > statically, so the runtime image ships no extra shared libraries and needs no GPU.
 

--- a/deploy/export_executorch.py
+++ b/deploy/export_executorch.py
@@ -108,7 +108,7 @@ def main():
     print("\nModel outputs:")
     print("  - dets: Bounding boxes [batch, num_queries, 4]")
     print("  - labels: Class logits [batch, num_queries, num_classes]")
-    print("\nNote: ExecuTorch export requires 'pip install rfdetr[executorch]==1.9.2'.")
+    print("\nNote: ExecuTorch export requires 'pip install rfdetr[executorch]==1.9.4'.")
     print("      The extra only constrains ExecuTorch to >=1.3,<2.0, so check what it")
     print("      installed ('pip show executorch'): the .pte must be exported with the")
     print("      same version as the C++ runtime, which this project pins to v1.4.0.")

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,1 +1,1 @@
-rfdetr[onnx]==1.9.2
+rfdetr[onnx]==1.9.4

--- a/docs/export.md
+++ b/docs/export.md
@@ -4,9 +4,9 @@ Follow the procedure listed at https://rfdetr.roboflow.com/learn/deploy/
 ## Requirements
 
 > [!IMPORTANT]
-> - Python version: **3.10+** (upstream `rfdetr` 1.9.2; Python 3.11 venv still recommended here)
+> - Python version: **3.10+** (upstream `rfdetr` 1.9.4; Python 3.11 venv still recommended here)
 > - Starting with RF-DETR 1.6.0, the export extra was renamed: use `pip install rfdetr[onnx]`
-> - **Tested version**: `rfdetr[onnx]==1.9.2`
+> - **Tested version**: `rfdetr[onnx]==1.9.4`
 > - Starting with RF-DETR 1.7.0, ONNX exports use variant filenames (e.g. `rfdetr-medium.onnx`, `rfdetr-seg-medium.onnx`) instead of the generic `inference_model.onnx`
 > - The `--simplify` flag was removed in 1.8.0 (already deprecated in 1.7.0). Export scripts no longer accept it.
 > - RF-DETR 1.8.x adds keypoint model export support via `RFDETRKeypointPreview`.
@@ -17,6 +17,12 @@ Follow the procedure listed at https://rfdetr.roboflow.com/learn/deploy/
 > - 1.9.1 gates the extras to interpreters that ship wheels: `[onnx]` pins `onnxruntime<1.24` on Python 3.10 (newer releases dropped cp310 wheels), and `[executorch]` installs empty on Python 3.14 (ExecuTorch ships cp310–cp313 only). On the recommended 3.11 venv both resolve exactly as before.
 > - 1.9.1 makes the exported models' own inference helpers resize the way `predict()` does (bilinear, half-pixel centers, `antialias=False`) instead of PIL's antialiased filters. This C++ project already resizes that way — see [Preprocessing parity](#preprocessing-parity) — so exported ONNX/`.pte` models score here exactly as they did before; only upstream's Python-side ONNX/TFLite inference and INT8 calibration change. Re-export INT8 TFLite models if you ship any (not consumed by this project).
 > - 1.9.1 speeds up ExecuTorch/XNNPACK export ~2.5× by recombining undelegated `addmm` into `aten.linear`. **This changes which kernels the `.pte` needs at run time** — see [ExecuTorch Model Export](#executorch-model-export).
+> - 1.9.2 changes nothing on the export or inference path — it is a training/dataset release. One item to know before retraining: hierarchical COCO datasets (Roboflow exports carrying a synthetic unannotated root category) no longer let that root consume a label slot, and `train`/`valid`/`test` now share one label mapping derived from `train`. A model retrained after that change has a different class layout than one trained before it, so **the label file you pass to `inference_app` must come from the same side of the change as the checkpoint**.
+> - 1.9.3 makes exported-model decoding multi-label. Its ONNX/TFLite reference decoders had been taking a per-query `argmax`, so any query scoring above threshold on more than one class silently lost the rest; they now rank the flattened *(query, class)* grid the way `PostProcess._select_topk` does. `PostProcess` itself switched from `torch.topk` to a stable `argsort`, fixing the tie order to descending score, then ascending flattened index. **This project's C++ postprocessing mirrors both changes** — see [How detections are selected](../README.md#how-detections-are-selected).
+> - 1.9.3 also fixes `SegmentationHead`'s `skip_blocks` branch to apply the learned `spatial_features_proj`. That is a training-loss fix only: the export path already applied the projection unconditionally, so exported models are byte-identical and no re-export is needed.
+> - 1.9.4 makes the background logit slot explicit, via a `background_class_id` argument on the same reference decoders (`-1` default, `None` to keep every slot, `0` for background-first checkpoints). Mirrored here as `--background-class-id`. Note upstream's `-1` default mis-decodes the official pretrained COCO weights — a real foreground category occupies their final slot — which is why the C++ default is `0`; see the flag's README entry.
+> - 1.9.4 also stops the TFLite helper from treating any lone rank-4 output as a segmentation mask (a keypoint export's `pred_keypoints` could be upsampled into `Detections.mask`). Not reachable here: this project selects output tensors by position under an explicit `--segmentation` / `--keypoint` mode, never by guessing from rank.
+> - The remaining 1.9.2–1.9.4 fixes are training, augmentation, dataset, and TFLite-conversion changes with no bearing on an exported detection/segmentation/keypoint model.
 
 ### Setup Virtual Environment
 
@@ -33,7 +39,7 @@ python3.11 -m venv rfdetr_venv
 source rfdetr_venv/bin/activate
 
 # Install RF-DETR with export dependencies (tested version)
-pip install rfdetr[onnx]==1.9.2
+pip install rfdetr[onnx]==1.9.4
 ```
 
 ---
@@ -159,7 +165,7 @@ RF-DETR 1.9.0 adds ExecuTorch (`.pte`) export for on-device inference. The C++ s
 through the ExecuTorch backend (`-DUSE_EXECUTORCH=ON`).
 
 ```bash
-pip install 'rfdetr[executorch]==1.9.2'
+pip install 'rfdetr[executorch]==1.9.4'
 pip show executorch   # confirm the runtime version it resolved
 ```
 
@@ -172,7 +178,7 @@ pip show executorch   # confirm the runtime version it resolved
 > explicitly (`pip install 'executorch==1.4.0'`) if it differs from the runtime you build against.
 
 > [!WARNING]
-> **A 1.9.1 `.pte` needs the optimized kernel set.** 1.9.1 recombines the `addmm` ops XNNPACK
+> **A 1.9.1+ `.pte` needs the optimized kernel set.** 1.9.1 recombines the `addmm` ops XNNPACK
 > leaves un-delegated back into `aten.linear` — 6 such calls in an `RFDETRNano` export at 384×384,
 > which is where its ~2.5× XNNPACK speedup comes from. `aten::linear.out` is registered only by
 > ExecuTorch's optimized kernels; the portable set registers `addmm.out` and `mm.out` but not
@@ -274,7 +280,7 @@ model = RFDETRMedium(pretrain_weights=<CHECKPOINT_PATH>)
 model.export(format="tensorrt", fp16=True)  # alias: format="trt"
 ```
 
-Requires `pip install 'rfdetr[tensorrt]==1.9.2'`, which provides `tensorrt` + `polygraphy`. The engine is built in-process through the polygraphy API rather than by shelling out to `trtexec`, so no `trtexec` binary is needed, and it is built for the local GPU architecture. Pass `fp16=False` on TensorRT builds that do not expose the FP16 builder flag.
+Requires `pip install 'rfdetr[tensorrt]==1.9.4'`, which provides `tensorrt` + `polygraphy`. The engine is built in-process through the polygraphy API rather than by shelling out to `trtexec`, so no `trtexec` binary is needed, and it is built for the local GPU architecture. Pass `fp16=False` on TensorRT builds that do not expose the FP16 builder flag.
 
 Note that `[tensorrt]` no longer installs `pycuda` as of 1.9.0 — that moved to the separate `[tensorrt-bench]` extra and is only needed for `TRTInference`'s async benchmarking mode. The standard export-to-engine path is unaffected.
 

--- a/specs/features/2026-08-25-rfdetr-1.9.4-alignment/plan.md
+++ b/specs/features/2026-08-25-rfdetr-1.9.4-alignment/plan.md
@@ -1,0 +1,61 @@
+# Plan: RF-DETR 1.9.3 / 1.9.4 Alignment
+
+Four groups. Group 1 is the contract and must land before 2 and 3, which are independent of each
+other. Group 4 is documentation and pins, required in the same commit by the Spec Sync rule in
+`AGENTS.md`.
+
+No new build targets, so nothing needs `CMakeLists.txt` registration: every file edited is already
+listed (`rfdetr_inference_lib` sources at `CMakeLists.txt`, `unit_tests` at the same file's test
+section). No new dependency — `specs/tech-stack.md` is unchanged except for the export pin row.
+
+## Group 1 — The shared selection contract (no GPU)
+
+1. `src/processing_utils.hpp` — declare `resolve_background_slot()`, `foreground_class_count()`,
+   `slot_for_foreground_column()`, `build_foreground_scores()`, `select_topk_multiclass()`. Document
+   each as a mirror of its upstream counterpart (`export/_class_layout.py`, `export/_topk.py`).
+2. `src/processing_utils.cpp` — implement them. `resolve_background_slot()` throws
+   `std::invalid_argument` on an out-of-range slot (upstream raises `ValueError`); NumPy negative
+   indexing supported. `select_topk_multiclass()` uses `std::partial_sort` over a NaN→`+inf`
+   ranking key with the comparator `key desc, index asc`.
+3. `src/rfdetr_inference.hpp` — add `Config::background_class_id` (`std::optional<int>`, default
+   `0`) and a reusable `score_grid_` member so the video path does not reallocate per frame.
+
+## Group 2 — CPU decode paths (no GPU)
+
+4. `src/rfdetr_inference.cpp` — anonymous-namespace `validate_config()`, called from both
+   constructors, rejecting a negative `max_detections`.
+5. `src/rfdetr_inference.cpp::postprocess_outputs()` — replace the per-query argmax with
+   `build_foreground_scores()` + `select_topk_multiclass()`; threshold with `score > threshold`;
+   decode `query = flat / C_fg`, `class_id = flat % C_fg`.
+6. `src/rfdetr_inference.cpp::postprocess_segmentation_outputs()` — same selection, replacing the
+   local score/index vectors and the score-only `partial_sort` comparator.
+7. `src/rfdetr_inference.cpp::postprocess_keypoint_outputs()` — same selection; recover the exported
+   slot with `slot_for_foreground_column()` for the `kp_map` lookup, which is slot-indexed.
+8. `src/main.cpp` — `--background-class-id <n|none>`, usage text, and the two-level "unset vs.
+   explicit none" parse.
+
+## Group 3 — CUDA mirror (**needs a GPU to verify**, compiles without one)
+
+9. `src/gpu/rfdetr_postprocess.hpp` — `SegPostprocessParams::background_slot`, documented as
+   "fill from `resolve_background_slot()`".
+10. `src/gpu/rfdetr_postprocess.cu` — `DeviceParams` gains `background_slot` and `num_foreground`;
+    `decode_scores` compacts the foreground columns before the sort; `select_and_decode` decodes
+    against `num_foreground` and drops NaN via `!(score > threshold)`; `Impl` sizes its scratch by
+    the foreground count and rejects an out-of-range slot.
+11. `src/rfdetr_inference.cpp::postprocess_segmentation_outputs_gpu()` — fill `background_slot`
+    from the same helper the CPU path uses.
+
+## Group 4 — Tests, pins, documentation (no GPU)
+
+12. `tests/unit/test_rfdetr_inference.cpp` — a `Config`-taking `make_inference()` overload, then one
+    test per new rule: multi-label, descending order, tie order, cap-before-threshold, NaN dropped,
+    `background_class_id` none / negative / out-of-range, negative `max_detections`, and the
+    segmentation path sharing the selection.
+13. `deploy/requirements.txt`, `deploy/export_executorch.py`,
+    `tests/integration/integration_test_rfdetr_inference.cpp` — pin and message text to 1.9.4.
+14. `specs/tech-stack.md` (export-tooling row), `specs/mission.md` ("currently **1.9.4**").
+15. `README.md` — `--background-class-id` in both option tables, and a "How detections are selected"
+    section covering multi-label ranking, cap-then-threshold order, and the tie rule.
+16. `docs/export.md` — what 1.9.2–1.9.4 do and do not change for an exported model.
+17. `CHANGELOG.md` — `[Unreleased]` entry in house style, after the 1.9.2 entry.
+18. `AGENTS.md` — the fetch-before-work rule (see `requirements.md` → Context).

--- a/specs/features/2026-08-25-rfdetr-1.9.4-alignment/requirements.md
+++ b/specs/features/2026-08-25-rfdetr-1.9.4-alignment/requirements.md
@@ -1,0 +1,100 @@
+# Requirements: RF-DETR 1.9.3 / 1.9.4 Alignment
+
+The standing obligation from [roadmap.md](../../roadmap.md) → Deferred: every upstream `rfdetr`
+release triggers an alignment pass. Follows the
+[rfdetr-alignment](../../../.claude/skills/rfdetr-alignment/SKILL.md) checklist. The 1.9.2 pass is
+already recorded in [CHANGELOG.md](../../../CHANGELOG.md); this covers
+[1.9.3](https://github.com/roboflow/rf-detr/releases/tag/1.9.3) and
+[1.9.4](https://github.com/roboflow/rf-detr/releases/tag/1.9.4).
+
+Unlike 1.9.2, these two **do** change the decode contract, so this is not a pins-and-docs pass.
+
+## Step 1 — Classification (skill Step 1)
+
+| Question | Answer |
+|----------|--------|
+| Exported model **inputs** change? | **No.** `export/_resize.py` is byte-identical between 1.9.1 and 1.9.4. `src/media.cpp` and `data/dali/` do not move. |
+| Exported **outputs** change? | **No** in shape/order/count — but their **decode** does. Tensor names, ranks, and positions are unchanged, so `validate_output_order()` in every backend is untouched. Every postprocess path changes, `src/gpu/rfdetr_postprocess.cu` included. |
+| Required **runtime operators** change? | **No.** `export/_executorch/` is byte-identical 1.9.1→1.9.4; ExecuTorch stays pinned at v1.4.0 and the `EXECUTORCH_BUILD_KERNELS_OPTIMIZED` requirement is unchanged. |
+| Public Python APIs used by `deploy/` change? | **No.** The new `background_class_id` / `rank4_output` arguments sit on private `_run_inference` helpers this project does not call. |
+| Training/dataset-only change? | **Partly** — most of both releases is. The exceptions are the two decode changes below. |
+
+### The two changes that reach C++
+
+1. **Multi-label selection** ([1.9.3 PR #1320](https://github.com/roboflow/rf-detr/pull/1320)).
+   RF-DETR scores classes with independent sigmoids, not a softmax, so one query can clear the
+   threshold on several classes at once. Upstream's ONNX/TFLite reference decoders took a per-query
+   `argmax` and silently dropped the rest; 1.9.3 replaced that with a flattened *(Q, C)* ranking
+   (new `rfdetr/export/_topk.py`), and changed `PostProcess._select_topk` from `torch.topk` to a
+   stable `argsort` so ties resolve as descending score, then ascending flattened index.
+   **This project had the same argmax bug** in `postprocess_outputs()` and
+   `postprocess_keypoint_outputs()`.
+2. **Explicit background logit slot** ([1.9.4 PR #1397](https://github.com/roboflow/rf-detr/pull/1397)).
+   The background slot is checkpoint-dependent and cannot be inferred from tensor width, so it
+   became an argument (new `rfdetr/export/_class_layout.py`). **This project hard-coded slot 0.**
+
+## Scope
+
+### In
+
+| Deliverable | Path |
+|-------------|------|
+| Shared selection + class-layout helpers | `src/processing_utils.{hpp,cpp}` |
+| Detection, segmentation, keypoint decode | `src/rfdetr_inference.cpp` |
+| `Config::background_class_id` | `src/rfdetr_inference.hpp` |
+| CUDA mirror of the same selection | `src/gpu/rfdetr_postprocess.{hpp,cu}` |
+| `--background-class-id` flag | `src/main.cpp` |
+| Unit coverage for every new rule | `tests/unit/test_rfdetr_inference.cpp` |
+| Pins | `deploy/requirements.txt`, `deploy/export_executorch.py`, `specs/tech-stack.md`, `specs/mission.md` |
+| Documentation | `README.md`, `docs/export.md`, `CHANGELOG.md` |
+
+### Out
+
+- **No re-export of the checked-in TensorRT engine.** `exports/model.engine` stays as is; the graph
+  did not change, only its host-side decode.
+- **No DALI pipeline regeneration.** Preprocessing is untouched, so `data/dali/*.dali` are still valid
+  ([gpu-pipeline.md](../../gpu-pipeline.md) rules 1–2 are not engaged).
+- **No `rank4_output` equivalent.** Upstream needed it because its TFLite helper guessed a mask from
+  any lone rank-4 output. This project selects outputs positionally under an explicit
+  `--segmentation` / `--keypoint` mode and never guesses, so there is nothing to port.
+- **No change to the 1.9.2 dataset/label-space work.** Python-side, covered by its own entry.
+
+## Decisions
+
+- **`background_class_id` defaults to `0`, not upstream's `-1`.** Upstream's own release notes state
+  that `-1` mis-decodes the official pretrained COCO weights, because a real foreground category
+  (id 90, `toothbrush`) occupies the final slot. This project's convention — logit 0 background,
+  logit *n* = COCO category *n*, `data/coco-labels-91.txt` indexed by COCO id — is upstream's
+  `background_class_id=0` case. Defaulting to `0` keeps every decoded label exactly where it was.
+- **The background column is excluded *before* ranking, not filtered after.** Upstream's
+  `_exclude_background_class` runs ahead of `_select_topk_multiclass`. Filtering afterwards (what the
+  segmentation path used to do) lets background candidates consume slots of the `num_select` cap.
+- **After exclusion, foreground column *c* is label index *c*.** Upstream keeps original exported
+  ids and maps them to names through a sparse dict; this project's label file is already id-indexed,
+  so the positional mapping is equivalent and preserves the existing `class_id` values.
+- **NaN ranks first, then fails the threshold.** Matches torch's descending-sort behaviour, which
+  `_topk.py` documents and reproduces with `np.where(np.isnan(...), np.inf, ...)`. It also makes the
+  comparator a strict weak ordering — the previous `a > b` on raw scores was undefined behaviour in
+  `std::partial_sort` the moment any score was NaN.
+- **One implementation, four call sites.** Per [mission.md](../../mission.md) architectural
+  commitments, the CPU and CUDA postprocessors are two implementations of one contract, so the rule
+  lives in `processing_utils.cpp` and the kernel mirrors it rather than re-deriving it.
+
+## Context
+
+- **This spec was written after the implementation**, contrary to the skill's ordering. The work
+  began from a local `develop` that was 4 commits behind `origin/develop` and therefore did not yet
+  contain `specs/` or the skills. Recorded here rather than quietly backdated. The fetch-first rule
+  added to `AGENTS.md` in this same change is the fix for the cause.
+- Existing patterns followed: `src/processing_utils.cpp:22-33` (small, `noexcept`, pure decode
+  helpers), `src/gpu/rfdetr_postprocess.cu:58-80` (one thread per (query, class) pair, `DeviceParams`
+  passed by value).
+- The CUDA path already satisfied the tie rule by accident: CUB's radix sort is stable, so equal
+  scores kept the ascending flattened index order `decode_scores` wrote them in. That is now written
+  down beside the sort so it is not lost to a future switch to an unstable sort.
+- Upstream sources for both mirrors, read from the 1.9.4 sdist: `rfdetr/export/_topk.py`,
+  `rfdetr/export/_class_layout.py`, `rfdetr/models/postprocess.py::PostProcess._select_topk`.
+- Open question carried forward: `Config::keypoint_counts` is indexed by exported logit slot while
+  `class_id` is now a label index. They are correctly distinguished in
+  `postprocess_keypoint_outputs()` via `slot_for_foreground_column()`, but a non-background-first
+  keypoint checkpoint would also need `keypoint_counts` re-based. No such checkpoint ships today.

--- a/specs/features/2026-08-25-rfdetr-1.9.4-alignment/validation.md
+++ b/specs/features/2026-08-25-rfdetr-1.9.4-alignment/validation.md
@@ -1,0 +1,78 @@
+# Validation: RF-DETR 1.9.3 / 1.9.4 Alignment
+
+Status recorded as of 2026-08-25. Anything not ticked is stated as such in `CHANGELOG.md` rather
+than implied to work, per the skill's Step 5.
+
+## Automated — no GPU
+
+Commands quoted from `AGENTS.md`.
+
+- [x] Default build: `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build --parallel`
+- [x] Unit tests: `ctest --test-dir build --output-on-failure -R UnitTests` — **52/52 pass**
+      (41 pre-existing + 11 added)
+- [x] Integration tests: `ctest --test-dir build --output-on-failure -R IntegrationTests` — passes;
+      the 4 model-backed cases report `SKIPPED` with no `.onnx` present, which is the documented
+      behaviour, not a failure
+- [x] Format: `find src tests -name '*.cpp' -o -name '*.hpp' | xargs clang-format-18 --dry-run --Werror` — clean
+- [x] Cppcheck: `cppcheck --enable=all --std=c++20 --suppress=missingIncludeSystem --suppress=unmatchedSuppression --suppress=unusedFunction --error-exitcode=1 -I src src/` — clean
+- [ ] Clang-tidy: `find src -name '*.cpp' | xargs clang-tidy-18 -p build` — **not run**
+
+### Selection rules pinned by test
+
+Each is an exact assertion, not a tolerance:
+
+| Rule | Test |
+|------|------|
+| A query above threshold on 2 classes yields 2 detections sharing one box | `PostprocessTest.MultiLabelQueryYieldsEveryClassAboveThreshold` |
+| Output is ordered by strictly descending score | `PostprocessTest.ResultsAreRankedByDescendingScore` |
+| Exact ties order by ascending flattened index — asserts `class_ids == {2, 3, 0, 1}` | `PostprocessTest.TiesResolveByAscendingFlattenedIndex` |
+| `max_detections` caps candidates *before* thresholding — 4 above threshold, cap 2, expect 2 | `PostprocessTest.MaxDetectionsCapsCandidatesBeforeThresholding` |
+| A NaN score is dropped, not emitted with NaN confidence | `PostprocessTest.NaNScoreIsDroppedNotKept` |
+| `background_class_id = none` keeps slot 0 as a real class | `PostprocessTest.BackgroundClassIdNoneKeepsEverySlot` |
+| `background_class_id = -1` excludes the final slot | `PostprocessTest.BackgroundClassIdCountsFromTheEnd` |
+| An out-of-range slot throws `std::invalid_argument` | `PostprocessTest.BackgroundClassIdOutOfRangeRejected` |
+| Negative `max_detections` throws at construction | `PostprocessTest.NegativeMaxDetectionsRejectedAtConstruction` |
+| Segmentation shares the identical selection | `PostprocessTest.SegmentationRanksFlattenedQueryClassPairs` |
+
+## Automated — with a device
+
+Run per [gpu-verify](../../../.claude/skills/gpu-verify/SKILL.md). Hardware used: RTX 3060 Laptop
+(sm_86), TensorRT 10.13.3.9, nvcc 12.0.
+
+- [x] Configure and build:
+      `cmake -S . -B build-gpu -G Ninja -DUSE_ONNX_RUNTIME=OFF -DUSE_TENSORRT=ON -DUSE_CUDA_POSTPROCESS=ON -DTENSORRT_ROOTDIR=$HOME/dependencies/TensorRT-10.13.3.9 -DCMAKE_BUILD_TYPE=Release`
+- [x] `build-gpu/unit_tests` — **62/62 pass** (52 CPU + 10 GPU)
+- [x] CPU-vs-GPU segmentation parity, all 6 cases pass: `MatchesCpuOnSparseDetections`,
+      `MatchesCpuOnDenseDetections` (saturates the cap at 50), `MatchesCpuOnNonSquareLargeFrame`,
+      `MatchesCpuWithNonZeroMaskThreshold`, `HandlesNoDetections`, `ReusesOneInstanceAcrossFrames`.
+      **Tolerance: exact.** These compare counts, class ids, scores, boxes, and mask bytes for
+      equality — the gate on Group 3, since the kernel now ranks a compacted candidate set and any
+      divergence from `select_topk_multiclass()` shows up as a mismatch.
+
+> First attempt failed all 10 with `cudaErrorMemoryAllocation` at `cudaSetDevice` — an unrelated
+> process held 5.2 GB of the 6 GB card. Re-run once free. Not a code failure; recorded so the
+> signature is recognisable.
+
+## Compile-without-device
+
+- [x] The GPU targets build on a machine with nvcc; `test_gpu_postprocess.cpp` reports `SKIPPED`
+      rather than `FAILED` when no device is present (`SKIP_WITHOUT_GPU()` guard, unchanged)
+- [x] The default ONNX Runtime build compiles with no CUDA toolchain at all
+
+## Manual
+
+- [ ] **Re-export at least one model with the new package version and run it end to end** — skill
+      Step 5, **not done**. `rfdetr_venv` currently holds rfdetr 1.8.0 and no `.onnx` is checked in;
+      this needs `pip install rfdetr[onnx]==1.9.4`, a re-export of `rf-detr-nano.pth`, and a run
+      through `inference_app`. Until then, the multi-label change is verified only against synthetic
+      tensors, never against real model output. Stated in `CHANGELOG.md`.
+- [ ] Visual check of `--background-class-id none` against a fine-tuned (0-based) checkpoint — no
+      such checkpoint available here.
+
+## Definition of done
+
+- [x] `CHANGELOG.md` updated under `[Unreleased]`, house style, per-file table
+- [x] `README.md` updated in the same change (Spec Sync rule)
+- [x] `specs/mission.md` and `specs/tech-stack.md` version statements propagated in the same commit
+- [ ] Roadmap items ticked — n/a, this is the standing obligation rather than a numbered phase
+- [ ] Branch merged into `develop` and deleted

--- a/specs/mission.md
+++ b/specs/mission.md
@@ -4,7 +4,7 @@ RF-DETR C++ Inference runs the RF-DETR model — object detection, instance segm
 
 The point is portability across runtimes. The same source builds against ONNX Runtime, TensorRT, or ExecuTorch, chosen at compile time, so the same postprocessing and drawing code serves a CPU laptop, an NVIDIA server, and an edge device. It handles single images and video, the latter through a multi-threaded ring-buffer pipeline, with an opt-in GPU pipeline (DALI preprocessing + CUDA segmentation postprocessing) on the TensorRT backend.
 
-The project is kept deliberately in step with upstream [`rfdetr`](https://github.com/roboflow/rf-detr) releases — currently **1.9.2**. Every upstream release triggers an alignment pass, recorded in [CHANGELOG.md](../CHANGELOG.md).
+The project is kept deliberately in step with upstream [`rfdetr`](https://github.com/roboflow/rf-detr) releases — currently **1.9.4**. Every upstream release triggers an alignment pass, recorded in [CHANGELOG.md](../CHANGELOG.md).
 
 ## Architectural commitments
 

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -13,7 +13,7 @@ Every version below cites the file that owns the pin. Change it there, not here 
 | Dependencies | apt / conan / vcpkg facade | — | `find_dependency_unified()`, `DEPS_MODE` default `apt` (`cmake/deps/Deps.cmake:6`) |
 | Format | clang-format | 18 | `.clang-format`: LLVM base, indent 4, column 120 |
 | Static analysis | clang-tidy 18, cppcheck | — | `.clang-tidy`; CI excludes `tensorrt_backend.cpp` from clang-tidy |
-| Export tooling | `rfdetr[onnx]` | 1.9.2 | `deploy/requirements.txt` — the only pinned pip requirement; ONNX opset 17 |
+| Export tooling | `rfdetr[onnx]` | 1.9.4 | `deploy/requirements.txt` — the only pinned pip requirement; ONNX opset 17 |
 | Vendored | stb, font8x8 | unversioned | `third_party/` — no install step |
 
 ## Inference backends

--- a/src/gpu/rfdetr_postprocess.cu
+++ b/src/gpu/rfdetr_postprocess.cu
@@ -34,6 +34,8 @@ struct DeviceParams {
     float mask_threshold;
     int max_detections;
     int num_labels;
+    int background_slot;
+    int num_foreground;
 };
 
 DeviceParams to_device_params(const SegPostprocessParams &p) {
@@ -50,22 +52,31 @@ DeviceParams to_device_params(const SegPostprocessParams &p) {
                         p.threshold,
                         p.mask_threshold,
                         p.max_detections,
-                        p.num_labels};
+                        p.num_labels,
+                        p.background_slot,
+                        p.background_slot < 0 ? p.num_classes : p.num_classes - 1};
 }
 
 /// Matches rfdetr::processing::sigmoid.
 __device__ __forceinline__ float sigmoid(float x) { return 1.0F / (1.0F + __expf(-x)); }
 
-/// One thread per (query, class) pair. The segmentation path ranks every pair
-/// globally rather than taking a per-query argmax, so a single query can yield
-/// several detections — see postprocess_segmentation_outputs.
+/// One thread per (query, foreground class) pair. The segmentation path ranks
+/// every pair globally rather than taking a per-query argmax, so a single query
+/// can yield several detections — see postprocess_segmentation_outputs.
+///
+/// The background column is dropped here, before ranking, exactly as
+/// `build_foreground_scores` drops it on the CPU: leaving it in would let
+/// background candidates consume slots of the top-k cap.
 __global__ void decode_scores(const float *__restrict__ labels, float *__restrict__ scores,
-                              int32_t *__restrict__ indices, int total) {
+                              int32_t *__restrict__ indices, DeviceParams p, int total) {
     const int i = static_cast<int>(blockIdx.x) * blockDim.x + threadIdx.x;
     if (i >= total) {
         return;
     }
-    scores[i] = sigmoid(labels[i]);
+    const int query = i / p.num_foreground;
+    const int column = i % p.num_foreground;
+    const int slot = (p.background_slot >= 0 && column >= p.background_slot) ? column + 1 : column;
+    scores[i] = sigmoid(labels[query * p.num_classes + slot]);
     indices[i] = i;
 }
 
@@ -87,16 +98,19 @@ __global__ void select_and_decode(const float *__restrict__ sorted_scores, const
     for (int k = 0; k < num_select; ++k) {
         const float score = sorted_scores[k];
         // Threshold after ranking, exactly as the CPU path does: the cap applies
-        // to the candidates examined, the threshold to the ones kept.
-        if (score <= p.threshold) {
+        // to the candidates examined, the threshold to the ones kept. Negated so
+        // a NaN score is dropped rather than kept, matching `score > threshold`
+        // on the CPU and upstream.
+        if (!(score > p.threshold)) {
             continue;
         }
 
         const int flat = sorted_indices[k];
-        const int query = flat / p.num_classes;
-        // Logit 0 is background; shift so that logit 1 becomes class 0.
-        const int class_id = (flat % p.num_classes) - 1;
-        if (class_id < 0 || class_id >= p.num_labels) {
+        const int query = flat / p.num_foreground;
+        // Ranking already dropped the background column, so the foreground column
+        // is the label index directly.
+        const int class_id = flat % p.num_foreground;
+        if (class_id >= p.num_labels) {
             continue;
         }
 
@@ -194,7 +208,7 @@ struct SegPostprocessor::Impl {
     SegPostprocessParams params;
     cudaStream_t stream{nullptr};
 
-    // Ranking scratch, sized by num_queries * num_classes.
+    // Ranking scratch, sized by num_queries * foreground classes.
     DeviceBuffer scores_in;
     DeviceBuffer scores_out;
     DeviceBuffer indices_in;
@@ -220,7 +234,12 @@ struct SegPostprocessor::Impl {
     size_t host_small_bytes{0};
 
     explicit Impl(const SegPostprocessParams &p, StreamHandle s) : params(p), stream(static_cast<cudaStream_t>(s)) {
-        const int total = p.num_queries * p.num_classes;
+        if (p.background_slot >= p.num_classes) {
+            throw std::runtime_error("Segmentation postprocess background slot does not index an exported class");
+        }
+        // Ranking runs over foreground pairs only; the background column is
+        // excluded before the sort, as it is on the CPU.
+        const int total = p.num_queries * (p.background_slot < 0 ? p.num_classes : p.num_classes - 1);
         if (total <= 0) {
             throw std::runtime_error("Segmentation postprocess needs positive num_queries and num_classes");
         }
@@ -288,14 +307,18 @@ void SegPostprocessor::run(const void *dets_device, const void *labels_device, c
         throw std::runtime_error("Segmentation postprocess frame geometry has not been set");
     }
 
-    const int total = p.num_queries * p.num_classes;
     const DeviceParams dp = to_device_params(p);
+    const int total = p.num_queries * dp.num_foreground;
 
     decode_scores<<<grid_for(total), kBlockSize, 0, s.stream>>>(static_cast<const float *>(labels_device),
                                                                 static_cast<float *>(s.scores_in.get()),
-                                                                static_cast<int32_t *>(s.indices_in.get()), total);
+                                                                static_cast<int32_t *>(s.indices_in.get()), dp, total);
     CUDA_CHECK_LAST();
 
+    // Radix sort is stable, so equal scores keep the ascending flattened index
+    // order decode_scores wrote them in — the same tie rule rfdetr 1.9.3 made
+    // explicit (`torch.argsort(..., stable=True)`) and that select_topk_multiclass
+    // applies on the CPU.
     size_t temp_bytes = s.sort_temp.capacity();
     CUDA_CHECK(cub::DeviceRadixSort::SortPairsDescending(
         s.sort_temp.get(), temp_bytes, static_cast<const float *>(s.scores_in.get()),

--- a/src/gpu/rfdetr_postprocess.hpp
+++ b/src/gpu/rfdetr_postprocess.hpp
@@ -29,6 +29,10 @@ struct SegPostprocessParams {
     float mask_threshold{0.0F}; ///< raw-logit threshold (NOT sigmoid-then-0.5)
     int max_detections{300};    ///< cap on the number of ranked candidates examined
     int num_labels{0};          ///< label-file size; class ids at or above it are dropped
+    /// Resolved exported logit slot holding background, or -1 to keep every slot.
+    /// Fill it from `rfdetr::processing::resolve_background_slot()` so the GPU and
+    /// CPU paths exclude the same column before ranking.
+    int background_slot{0};
 };
 
 /// Packed segmentation results, host side.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,7 @@ int main(int argc, const char *argv[]) {
         std::cerr << "Usage: " << argv[0]
                   << " <path_to_model> <path_to_image_or_video> <path_to_coco_labels> [--segmentation|--keypoint] "
                      "[--threshold <val>] [--resolution <px>] [--max-detections <n>] [--mask-threshold <val>] "
+                     "[--background-class-id <n|none>] "
                      "[--display] [--gpu-preprocess] [--gpu-postprocess] [--dali-pipeline-dir <dir>]"
                   << std::endl;
         std::cerr << "Examples:" << std::endl;
@@ -93,6 +94,9 @@ int main(int argc, const char *argv[]) {
         std::cerr << "Note: exactly one backend is selected at compile time; this binary was built with" << std::endl;
         std::cerr << "      " << kBackendDescription << std::endl;
         std::cerr << "      Rebuild with " << kBackendBuildFlags << " to select it explicitly." << std::endl;
+        std::cerr << "      --background-class-id selects the exported logit slot holding background" << std::endl;
+        std::cerr << "      (default 0 = background-first, as the shipped RF-DETR exports are;" << std::endl;
+        std::cerr << "      negative counts from the end, 'none' keeps every slot)." << std::endl;
         std::cerr << "      --gpu-preprocess needs -DUSE_DALI=ON, --gpu-postprocess needs" << std::endl;
         std::cerr << "      -DUSE_CUDA_POSTPROCESS=ON; both require the TensorRT backend." << std::endl;
         return 1;
@@ -115,6 +119,10 @@ int main(int argc, const char *argv[]) {
     std::optional<int> max_detections;
     std::optional<float> threshold;
     std::optional<float> mask_threshold;
+    // Two levels of "unset": no flag at all leaves the Config default, while
+    // --background-class-id none is an explicit request to keep every logit slot.
+    bool background_class_id_given = false;
+    std::optional<int> background_class_id;
 
     for (int i = 4; i < argc; ++i) {
         if (std::strcmp(argv[i], "--segmentation") == 0) {
@@ -139,6 +147,14 @@ int main(int argc, const char *argv[]) {
             }
         } else if (std::strcmp(argv[i], "--max-detections") == 0 && i + 1 < argc) {
             if (!parse_int_option("--max-detections", argv[++i], max_detections)) {
+                return 1;
+            }
+        } else if (std::strcmp(argv[i], "--background-class-id") == 0 && i + 1 < argc) {
+            const char *value = argv[++i];
+            background_class_id_given = true;
+            if (std::strcmp(value, "none") == 0) {
+                background_class_id.reset();
+            } else if (!parse_int_option("--background-class-id", value, background_class_id)) {
                 return 1;
             }
         } else if (std::strcmp(argv[i], "--mask-threshold") == 0 && i + 1 < argc) {
@@ -196,6 +212,9 @@ int main(int argc, const char *argv[]) {
         }
         if (mask_threshold) {
             config.mask_threshold = *mask_threshold;
+        }
+        if (background_class_id_given) {
+            config.background_class_id = background_class_id;
         }
 
         if (is_video_file(input_path)) {

--- a/src/processing_utils.cpp
+++ b/src/processing_utils.cpp
@@ -3,6 +3,10 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <limits>
+#include <numeric>
+#include <stdexcept>
+#include <string>
 
 namespace rfdetr::processing {
 
@@ -30,6 +34,73 @@ BoundingBox scale_box(const BoundingBox &box, float scale_w, float scale_h) noex
 BoundingBox clamp_box(const BoundingBox &box, float max_w, float max_h) noexcept {
     return {std::clamp(box.x_min, 0.0f, max_w), std::clamp(box.y_min, 0.0f, max_h), std::clamp(box.x_max, 0.0f, max_w),
             std::clamp(box.y_max, 0.0f, max_h)};
+}
+
+int resolve_background_slot(std::optional<int> background_class_id, int num_classes) {
+    if (num_classes <= 0) {
+        throw std::invalid_argument("num_classes must be positive, got " + std::to_string(num_classes));
+    }
+    if (!background_class_id.has_value()) {
+        return -1;
+    }
+    const int slot = *background_class_id;
+    if (slot < -num_classes || slot >= num_classes) {
+        throw std::invalid_argument("background class id must index one of " + std::to_string(num_classes) +
+                                    " exported class slots, got " + std::to_string(slot));
+    }
+    return slot < 0 ? slot + num_classes : slot;
+}
+
+int foreground_class_count(int num_classes, int background_slot) noexcept {
+    return background_slot < 0 ? num_classes : num_classes - 1;
+}
+
+int slot_for_foreground_column(int column, int background_slot) noexcept {
+    return (background_slot >= 0 && column >= background_slot) ? column + 1 : column;
+}
+
+void build_foreground_scores(std::span<const float> logits, int num_queries, int num_classes, int background_slot,
+                             std::vector<float> &scores) {
+    const int num_foreground = foreground_class_count(num_classes, background_slot);
+    scores.clear();
+    if (num_queries <= 0 || num_foreground <= 0) {
+        return;
+    }
+    scores.reserve(static_cast<size_t>(num_queries) * static_cast<size_t>(num_foreground));
+    for (int q = 0; q < num_queries; ++q) {
+        const size_t row = static_cast<size_t>(q) * static_cast<size_t>(num_classes);
+        for (int column = 0; column < num_foreground; ++column) {
+            const size_t slot = static_cast<size_t>(slot_for_foreground_column(column, background_slot));
+            scores.push_back(sigmoid(logits[row + slot]));
+        }
+    }
+}
+
+std::vector<size_t> select_topk_multiclass(std::span<const float> scores, size_t num_select) {
+    const size_t count = std::min(num_select, scores.size());
+    std::vector<size_t> order(scores.size());
+    if (count == 0) {
+        order.clear();
+        return order;
+    }
+    std::iota(order.begin(), order.end(), size_t{0});
+
+    // Rank NaN ahead of every finite score, the way torch's descending sort does.
+    // Substituting the key keeps the comparator a strict weak ordering, which a
+    // raw NaN comparison would not be.
+    const auto rank_key = [scores](size_t index) {
+        const float score = scores[index];
+        return std::isnan(score) ? std::numeric_limits<float>::infinity() : score;
+    };
+    std::partial_sort(order.begin(), order.begin() + static_cast<ptrdiff_t>(count), order.end(),
+                      [&rank_key](size_t lhs, size_t rhs) {
+                          const float lhs_key = rank_key(lhs);
+                          const float rhs_key = rank_key(rhs);
+                          // Descending score, then ascending flattened index.
+                          return lhs_key != rhs_key ? lhs_key > rhs_key : lhs < rhs;
+                      });
+    order.resize(count);
+    return order;
 }
 
 } // namespace rfdetr::processing

--- a/src/processing_utils.hpp
+++ b/src/processing_utils.hpp
@@ -4,7 +4,9 @@
 
 #include <array>
 #include <cstddef>
+#include <optional>
 #include <span>
+#include <vector>
 
 namespace rfdetr::processing {
 
@@ -25,5 +27,56 @@ using ::BoundingBox;
 
 /// Clamp a bounding box to image bounds [0, max_w] x [0, max_h]
 [[nodiscard]] BoundingBox clamp_box(const BoundingBox &box, float max_w, float max_h) noexcept;
+
+// --- Class layout and top-k selection ------------------------------------
+//
+// Mirrors of rfdetr's `export/_class_layout.py` and `export/_topk.py` (added in
+// 1.9.4 and 1.9.3), which are themselves torch-free copies of
+// `PostProcess._exclude_background_class` / `PostProcess._select_topk`. Keeping
+// the decode here in one place lets the detection, segmentation and keypoint
+// paths — and the CUDA kernels — share one selection rule.
+
+/// Resolve which exported logit slot holds background.
+///
+/// `background_class_id` follows upstream's NumPy indexing convention: a
+/// negative value counts from the end (`-1` = final slot) and `std::nullopt`
+/// keeps every slot. Returns the resolved slot in `[0, num_classes)`, or -1 when
+/// no slot is excluded.
+///
+/// Throws `std::invalid_argument` when the slot does not index one of the
+/// exported classes, matching upstream's `ValueError`.
+[[nodiscard]] int resolve_background_slot(std::optional<int> background_class_id, int num_classes);
+
+/// Number of foreground slots left once `background_slot` (-1 for none) is excluded.
+[[nodiscard]] int foreground_class_count(int num_classes, int background_slot) noexcept;
+
+/// Exported logit slot backing foreground column `column`.
+///
+/// Excluding the background column leaves the remaining slots in their original
+/// order, so foreground column `c` is the `c`-th label in the label file — that
+/// positional mapping is what turns a decoded column into a class id.
+[[nodiscard]] int slot_for_foreground_column(int column, int background_slot) noexcept;
+
+/// Sigmoid a `(num_queries, num_classes)` logit grid into the
+/// `(num_queries, foreground_class_count(...))` score grid that ranking consumes,
+/// dropping the background column. Excluding it *before* ranking matters: a
+/// background column left in would consume slots of the top-k cap.
+void build_foreground_scores(std::span<const float> logits, int num_queries, int num_classes, int background_slot,
+                             std::vector<float> &scores);
+
+/// Rank a flattened `(Q, C_fg)` score grid and return the top `num_select` indices.
+///
+/// Mirror of `_select_topk_multiclass`: RF-DETR scores classes with independent
+/// sigmoids rather than a softmax, so one query can legitimately clear the
+/// threshold on several classes at once. Ranking the flattened query/class pairs
+/// keeps all of them, where a per-query argmax would silently drop every class
+/// but the strongest.
+///
+/// Ordering is the deterministic lexicographic rule 1.9.3 introduced on both
+/// sides (`torch.argsort(..., stable=True)` upstream): descending score, then
+/// ascending flattened index. NaN scores rank first, as they do in torch's
+/// descending sort, so the caller's `score > threshold` test drops them instead
+/// of letting a lower finite score take their place under the cap.
+[[nodiscard]] std::vector<size_t> select_topk_multiclass(std::span<const float> scores, size_t num_select);
 
 } // namespace rfdetr::processing

--- a/src/rfdetr_inference.cpp
+++ b/src/rfdetr_inference.cpp
@@ -8,10 +8,27 @@
 #include <iostream>
 #include <numeric>
 #include <stdexcept>
+#include <string>
+
+namespace {
+
+/// rfdetr 1.9.3 made `PostProcess(num_select=<negative>)` a construction-time
+/// error rather than a silently accepted no-op; the cap is validated here for
+/// the same reason.
+void validate_config(const Config &config) {
+    if (config.max_detections < 0) {
+        throw std::invalid_argument("max_detections must be non-negative, got " +
+                                    std::to_string(config.max_detections));
+    }
+}
+
+} // namespace
 
 RFDETRInference::RFDETRInference(const std::filesystem::path &model_path, const std::filesystem::path &label_file_path,
                                  const Config &config)
     : backend_(create_backend()), config_(config), input_shape_({1, 3, config_.resolution, config_.resolution}) {
+
+    validate_config(config_);
 
     std::cout << "Using backend: " << backend_->get_backend_name() << std::endl;
 
@@ -46,6 +63,7 @@ RFDETRInference::RFDETRInference(const std::filesystem::path &model_path, const 
 RFDETRInference::RFDETRInference(std::unique_ptr<InferenceBackend> backend,
                                  const std::filesystem::path &label_file_path, const Config &config)
     : backend_(std::move(backend)), config_(config), input_shape_({1, 3, config_.resolution, config_.resolution}) {
+    validate_config(config_);
     load_coco_labels(label_file_path);
 }
 
@@ -125,46 +143,54 @@ void RFDETRInference::postprocess_outputs(float scale_w, float scale_h, std::vec
     const auto &labels_data = output_data_cache_[1];
     const auto &labels_shape = output_shapes_cache_[1];
 
-    const auto num_detections = static_cast<size_t>(dets_shape[1]);
-    const auto num_classes = static_cast<size_t>(labels_shape[2]);
+    const auto num_queries = static_cast<int>(dets_shape[1]);
+    const auto num_classes = static_cast<int>(labels_shape[2]);
     const auto res = static_cast<float>(config_.resolution);
     const auto max_w = scale_w * res;
     const auto max_h = scale_h * res;
 
-    for (size_t i = 0; i < num_detections; ++i) {
-        const size_t det_offset = i * static_cast<size_t>(dets_shape[2]);
-        const size_t label_offset = i * num_classes;
+    // Rank the flattened query/class grid rather than taking a per-query argmax:
+    // RF-DETR's class scores are independent sigmoids, so one query can clear the
+    // threshold on several classes and an argmax would drop all but the strongest
+    // (rfdetr 1.9.3, PR #1320). Results come out in descending-score order.
+    const int background_slot = rfdetr::processing::resolve_background_slot(config_.background_class_id, num_classes);
+    const auto num_foreground =
+        static_cast<size_t>(rfdetr::processing::foreground_class_count(num_classes, background_slot));
 
-        float max_score = -1.0f;
-        int max_class_idx = -1;
-        for (size_t j = 0; j < num_classes; ++j) {
-            const float logit = labels_data[label_offset + j];
-            const float score = rfdetr::processing::sigmoid(logit);
-            if (score > max_score) {
-                max_score = score;
-                max_class_idx = static_cast<int>(j);
-            }
+    rfdetr::processing::build_foreground_scores(labels_data, num_queries, num_classes, background_slot, score_grid_);
+    const auto ranked =
+        rfdetr::processing::select_topk_multiclass(score_grid_, static_cast<size_t>(config_.max_detections));
+
+    for (const size_t flat : ranked) {
+        const float score = score_grid_[flat];
+        // Negated so a NaN score is dropped rather than kept, matching upstream's
+        // `scores > threshold` filter. The cap applies to the candidates ranked,
+        // the threshold to the ones kept.
+        if (!(score > config_.threshold)) {
+            continue;
         }
 
-        max_class_idx -= 1; // Fix the +1 offset
-
-        if (max_score > config_.threshold && max_class_idx >= 0 &&
-            static_cast<size_t>(max_class_idx) < coco_labels_.size()) {
-            const float cx = dets_data[det_offset + 0] * res;
-            const float cy = dets_data[det_offset + 1] * res;
-            const float w = dets_data[det_offset + 2] * res;
-            const float h = dets_data[det_offset + 3] * res;
-
-            auto xyxy = rfdetr::processing::cxcywh_to_xyxy(cx, cy, w, h);
-            auto scaled = rfdetr::processing::scale_box(xyxy, scale_w, scale_h);
-            auto clamped = rfdetr::processing::clamp_box(scaled, max_w, max_h);
-
-            BoundingBox box{clamped.x_min, clamped.y_min, clamped.x_max, clamped.y_max};
-
-            scores.push_back(max_score);
-            class_ids.push_back(max_class_idx);
-            boxes.push_back(std::move(box));
+        const size_t query = flat / num_foreground;
+        const auto class_id = static_cast<int>(flat % num_foreground);
+        if (static_cast<size_t>(class_id) >= coco_labels_.size()) {
+            continue;
         }
+
+        const size_t det_offset = query * static_cast<size_t>(dets_shape[2]);
+        const float cx = dets_data[det_offset + 0] * res;
+        const float cy = dets_data[det_offset + 1] * res;
+        const float w = dets_data[det_offset + 2] * res;
+        const float h = dets_data[det_offset + 3] * res;
+
+        auto xyxy = rfdetr::processing::cxcywh_to_xyxy(cx, cy, w, h);
+        auto scaled = rfdetr::processing::scale_box(xyxy, scale_w, scale_h);
+        auto clamped = rfdetr::processing::clamp_box(scaled, max_w, max_h);
+
+        BoundingBox box{clamped.x_min, clamped.y_min, clamped.x_max, clamped.y_max};
+
+        scores.push_back(score);
+        class_ids.push_back(class_id);
+        boxes.push_back(std::move(box));
     }
 }
 
@@ -189,47 +215,32 @@ void RFDETRInference::postprocess_segmentation_outputs(float scale_w, float scal
     const auto &masks_data = output_data_cache_[2];
     const auto &masks_shape = output_shapes_cache_[2];
 
-    const auto num_detections = static_cast<size_t>(dets_shape[1]);
-    const auto num_classes = static_cast<size_t>(labels_shape[2]);
+    const auto num_queries = static_cast<int>(dets_shape[1]);
+    const auto num_classes = static_cast<int>(labels_shape[2]);
     const auto mask_h = static_cast<size_t>(masks_shape[2]);
     const auto mask_w = static_cast<size_t>(masks_shape[3]);
 
-    // Compute scores and apply sigmoid
-    std::vector<float> all_scores;
-    std::vector<size_t> all_indices;
+    // Same flattened query/class ranking the detection path uses — see
+    // postprocess_outputs() — so a query whose mask covers two classes yields
+    // both, and ties resolve deterministically.
+    const int background_slot = rfdetr::processing::resolve_background_slot(config_.background_class_id, num_classes);
+    const auto num_foreground =
+        static_cast<size_t>(rfdetr::processing::foreground_class_count(num_classes, background_slot));
 
-    for (size_t i = 0; i < num_detections; ++i) {
-        for (size_t j = 0; j < num_classes; ++j) {
-            const size_t label_offset = i * num_classes;
-            const float logit = labels_data[label_offset + j];
-            const float score = rfdetr::processing::sigmoid(logit);
-            all_scores.push_back(score);
-            all_indices.push_back(i * num_classes + j);
-        }
-    }
+    rfdetr::processing::build_foreground_scores(labels_data, num_queries, num_classes, background_slot, score_grid_);
+    const auto ranked =
+        rfdetr::processing::select_topk_multiclass(score_grid_, static_cast<size_t>(config_.max_detections));
 
-    // Top-k selection
-    const size_t num_select = std::min(static_cast<size_t>(config_.max_detections), all_scores.size());
-    std::vector<size_t> topk_indices(all_scores.size());
-    std::iota(topk_indices.begin(), topk_indices.end(), 0);
-    std::partial_sort(topk_indices.begin(), topk_indices.begin() + static_cast<ptrdiff_t>(num_select),
-                      topk_indices.end(),
-                      [&all_scores](size_t i1, size_t i2) { return all_scores[i1] > all_scores[i2]; });
-
-    // Process top-k detections
-    for (size_t k = 0; k < num_select; ++k) {
-        const size_t idx = topk_indices[k];
-        const float score = all_scores[idx];
-
-        if (score <= config_.threshold) {
+    for (const size_t flat : ranked) {
+        const float score = score_grid_[flat];
+        if (!(score > config_.threshold)) {
             continue;
         }
 
-        const size_t detection_idx = all_indices[idx] / num_classes;
-        const size_t class_idx = all_indices[idx] % num_classes;
-        const int class_id = static_cast<int>(class_idx) - 1; // Fix the +1 offset
+        const size_t detection_idx = flat / num_foreground;
+        const auto class_id = static_cast<int>(flat % num_foreground);
 
-        if (class_id < 0 || static_cast<size_t>(class_id) >= coco_labels_.size()) {
+        if (static_cast<size_t>(class_id) >= coco_labels_.size()) {
             continue;
         }
 
@@ -358,27 +369,37 @@ void RFDETRInference::postprocess_keypoint_outputs(float scale_w, float scale_h,
 
     const float res = static_cast<float>(config_.resolution);
 
-    for (size_t q = 0; q < num_queries; ++q) {
-        const size_t det_offset = q * static_cast<size_t>(dets_shape[2]);
-        const size_t label_offset = q * num_classes;
+    // Keypoint labels share the detection path's class layout and its flattened
+    // query/class ranking (see postprocess_outputs()). The shipped keypoint
+    // checkpoints are background-first — logit 0 is background, logit 1 the first
+    // real class (COCO person for the preview model) — which is what
+    // `Config::background_class_id`'s default 0 and `keypoint_counts`' leading 0
+    // both encode; upstream calls the same layout `background_class_id=0`.
+    const int background_slot =
+        rfdetr::processing::resolve_background_slot(config_.background_class_id, static_cast<int>(num_classes));
+    const auto num_foreground =
+        static_cast<size_t>(rfdetr::processing::foreground_class_count(static_cast<int>(num_classes), background_slot));
 
-        // RF-DETR keypoint labels use the same offset as detection: logit 0 is background,
-        // logit 1 is the first real class (COCO person for the preview model).
-        float best_score = -1.0f;
-        int best_class_idx = -1;
-        for (size_t j = 0; j < num_classes; ++j) {
-            const float logit = labels_data[label_offset + j];
-            const float score = rfdetr::processing::sigmoid(logit);
-            if (score > best_score) {
-                best_score = score;
-                best_class_idx = static_cast<int>(j);
-            }
-        }
+    rfdetr::processing::build_foreground_scores(labels_data, static_cast<int>(num_queries),
+                                                static_cast<int>(num_classes), background_slot, score_grid_);
+    const auto ranked =
+        rfdetr::processing::select_topk_multiclass(score_grid_, static_cast<size_t>(config_.max_detections));
 
-        const int class_id = best_class_idx - 1;
-        if (best_score <= config_.threshold || class_id < 0 || static_cast<size_t>(class_id) >= coco_labels_.size()) {
+    for (const size_t flat : ranked) {
+        const float best_score = score_grid_[flat];
+        if (!(best_score > config_.threshold)) {
             continue;
         }
+
+        const size_t q = flat / num_foreground;
+        const auto class_id = static_cast<int>(flat % num_foreground);
+        if (static_cast<size_t>(class_id) >= coco_labels_.size()) {
+            continue;
+        }
+        // kp_counts / kp_map are indexed by exported logit slot, not by label index.
+        const int best_class_idx = rfdetr::processing::slot_for_foreground_column(class_id, background_slot);
+
+        const size_t det_offset = q * static_cast<size_t>(dets_shape[2]);
 
         // Decode bbox
         const float cx = dets_data[det_offset + 0] * res;
@@ -702,6 +723,8 @@ void RFDETRInference::postprocess_segmentation_outputs_gpu(float scale_w, float 
         params.mask_threshold = config_.mask_threshold;
         params.max_detections = config_.max_detections;
         params.num_labels = static_cast<int>(coco_labels_.size());
+        params.background_slot =
+            rfdetr::processing::resolve_background_slot(config_.background_class_id, params.num_classes);
         params.orig_w = orig_w;
         params.orig_h = orig_h;
         params.scale_w = scale_w;

--- a/src/rfdetr_inference.hpp
+++ b/src/rfdetr_inference.hpp
@@ -31,8 +31,20 @@ struct Config {
     std::array<float, 3> means{0.485f, 0.456f, 0.406f};
     std::array<float, 3> stds{0.229f, 0.224f, 0.225f};
     ModelType model_type{ModelType::DETECTION};
-    int max_detections{300};
+    int max_detections{300}; ///< Cap on ranked query/class candidates, upstream's `num_select`
     float mask_threshold{0.0f};
+
+    /// Exported logit slot that holds background, excluded before ranking.
+    ///
+    /// Mirrors the `background_class_id` argument rfdetr 1.9.4 added to its own
+    /// ONNX/TFLite decoders. Negative values count from the end (`-1` = final
+    /// slot) and `std::nullopt` keeps every slot. The default 0 matches the
+    /// background-first layout the shipped RF-DETR exports use: logit 0 is
+    /// background and logit *n* is COCO category *n*, so the surviving slots map
+    /// in order onto the label file (`data/coco-labels-91.txt`, indexed by COCO
+    /// id). Upstream's own default is `-1`, which mis-decodes exactly these
+    /// checkpoints — their final slot is the real category 90.
+    std::optional<int> background_class_id{0};
 
     // Keypoint-specific configuration
     std::vector<int> keypoint_counts{
@@ -156,6 +168,10 @@ class RFDETRInference {
     // Output tensor cache
     std::vector<std::vector<float>> output_data_cache_;
     std::vector<std::vector<int64_t>> output_shapes_cache_;
+
+    /// Reusable (num_queries, foreground classes) score grid that top-k ranking
+    /// consumes, so a video run does not reallocate it per frame.
+    std::vector<float> score_grid_;
 
 #if defined(USE_CUDA_POSTPROCESS) || defined(USE_DALI)
     /// Lazily built on first use so a CPU-only run never touches the device.

--- a/tests/integration/integration_test_rfdetr_inference.cpp
+++ b/tests/integration/integration_test_rfdetr_inference.cpp
@@ -96,7 +96,7 @@ void save_white_test_image(const std::filesystem::path &path, int width = 100, i
     do {                                                                                                               \
         if (!(fixture).model_available_) {                                                                             \
             GTEST_SKIP() << "No " << kModelFormatName                                                                  \
-                         << " found for the compiled-in backend. Export with rfdetr 1.9.2 or set "                     \
+                         << " found for the compiled-in backend. Export with rfdetr 1.9.4 or set "                     \
                             "RFDETR_TEST_MODEL.";                                                                      \
         }                                                                                                              \
     } while (0)

--- a/tests/unit/test_rfdetr_inference.cpp
+++ b/tests/unit/test_rfdetr_inference.cpp
@@ -9,6 +9,8 @@
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <limits>
+#include <optional>
 #include <thread>
 
 // ============================================================================
@@ -269,7 +271,14 @@ class PostprocessTest : public ::testing::Test {
         Config config;
         config.resolution = resolution;
         config.threshold = threshold;
+        return make_inference(std::move(output_data), std::move(output_shapes), config);
+    }
 
+    // Same, for tests that need to vary more of the Config than threshold/resolution.
+    std::unique_ptr<RFDETRInference> make_inference(std::vector<std::vector<float>> output_data,
+                                                    std::vector<std::vector<int64_t>> output_shapes,
+                                                    const Config &config) {
+        const int resolution = config.resolution;
         auto backend = std::make_unique<MockBackend>();
         backend->set_outputs(std::move(output_data), std::move(output_shapes));
 
@@ -424,6 +433,255 @@ TEST_F(PostprocessTest, BoxesClampedToImageBounds) {
     EXPECT_NEAR(boxes[1].y_min, 80.0f, 0.01f);
     EXPECT_NEAR(boxes[1].x_max, 100.0f, 0.01f);
     EXPECT_NEAR(boxes[1].y_max, 100.0f, 0.01f);
+}
+
+// --- Multi-class top-k selection (rfdetr 1.9.3, PR #1320) -------------------
+//
+// Class scores are independent sigmoids, so ranking the flattened query/class
+// grid is what keeps a query that clears the threshold on several classes. The
+// per-query argmax these paths used before silently dropped all but the
+// strongest class.
+
+TEST_F(PostprocessTest, MultiLabelQueryYieldsEveryClassAboveThreshold) {
+    const int num_dets = 1;
+    const int num_classes = 6;
+
+    std::vector<float> dets_data = {0.5f, 0.5f, 0.2f, 0.1f};
+
+    // One query scoring high on two classes at once ("car" and "truck" in the
+    // upstream example): slot 1 -> label 0, slot 3 -> label 2.
+    std::vector<float> labels_data(static_cast<size_t>(num_classes), -10.0f);
+    labels_data[1] = 4.0f;
+    labels_data[3] = 6.0f;
+
+    auto inference =
+        make_inference({dets_data, labels_data}, {{1, num_dets, 4}, {1, num_dets, num_classes}}, 0.5f, 560);
+
+    std::vector<float> scores;
+    std::vector<int> class_ids;
+    std::vector<BoundingBox> boxes;
+    inference->postprocess_outputs(1.0f, 1.0f, scores, class_ids, boxes);
+
+    ASSERT_EQ(scores.size(), 2u);
+    // Ranked by descending score, so the stronger class comes first.
+    EXPECT_EQ(class_ids[0], 2);
+    EXPECT_EQ(class_ids[1], 0);
+    EXPECT_GT(scores[0], scores[1]);
+    // Both detections address the same query, so they share its box.
+    EXPECT_FLOAT_EQ(boxes[0].x_min, boxes[1].x_min);
+    EXPECT_FLOAT_EQ(boxes[0].y_max, boxes[1].y_max);
+}
+
+TEST_F(PostprocessTest, ResultsAreRankedByDescendingScore) {
+    const int num_dets = 3;
+    const int num_classes = 6;
+
+    std::vector<float> dets_data(static_cast<size_t>(num_dets * 4), 0.5f);
+    std::vector<float> labels_data(static_cast<size_t>(num_dets * num_classes), -10.0f);
+    labels_data[1] = 2.0f;                     // query 0, weakest
+    labels_data[num_classes + 1] = 8.0f;       // query 1, strongest
+    labels_data[(2 * num_classes) + 1] = 5.0f; // query 2
+
+    auto inference =
+        make_inference({dets_data, labels_data}, {{1, num_dets, 4}, {1, num_dets, num_classes}}, 0.5f, 560);
+
+    std::vector<float> scores;
+    std::vector<int> class_ids;
+    std::vector<BoundingBox> boxes;
+    inference->postprocess_outputs(1.0f, 1.0f, scores, class_ids, boxes);
+
+    ASSERT_EQ(scores.size(), 3u);
+    EXPECT_GT(scores[0], scores[1]);
+    EXPECT_GT(scores[1], scores[2]);
+}
+
+TEST_F(PostprocessTest, TiesResolveByAscendingFlattenedIndex) {
+    const int num_dets = 2;
+    const int num_classes = 6;
+
+    std::vector<float> dets_data(static_cast<size_t>(num_dets * 4), 0.5f);
+    std::vector<float> labels_data(static_cast<size_t>(num_dets * num_classes), -10.0f);
+    // Four exactly equal scores across both queries. Upstream's stable rule
+    // (descending score, then ascending flattened query/class index) fixes the
+    // order: (q0,slot3), (q0,slot4), (q1,slot1), (q1,slot2).
+    labels_data[3] = 7.0f;
+    labels_data[4] = 7.0f;
+    labels_data[num_classes + 1] = 7.0f;
+    labels_data[num_classes + 2] = 7.0f;
+
+    auto inference =
+        make_inference({dets_data, labels_data}, {{1, num_dets, 4}, {1, num_dets, num_classes}}, 0.5f, 560);
+
+    std::vector<float> scores;
+    std::vector<int> class_ids;
+    std::vector<BoundingBox> boxes;
+    inference->postprocess_outputs(1.0f, 1.0f, scores, class_ids, boxes);
+
+    ASSERT_EQ(class_ids.size(), 4u);
+    EXPECT_EQ(class_ids, (std::vector<int>{2, 3, 0, 1}));
+}
+
+TEST_F(PostprocessTest, MaxDetectionsCapsCandidatesBeforeThresholding) {
+    const int num_dets = 4;
+    const int num_classes = 6;
+
+    Config config;
+    config.resolution = 560;
+    config.threshold = 0.5f;
+    config.max_detections = 2;
+
+    std::vector<float> dets_data(static_cast<size_t>(num_dets * 4), 0.5f);
+    std::vector<float> labels_data(static_cast<size_t>(num_dets * num_classes), -10.0f);
+    for (int q = 0; q < num_dets; ++q) {
+        labels_data[static_cast<size_t>(q * num_classes) + 1] = 5.0f + static_cast<float>(q);
+    }
+
+    auto inference = make_inference({dets_data, labels_data}, {{1, num_dets, 4}, {1, num_dets, num_classes}}, config);
+
+    std::vector<float> scores;
+    std::vector<int> class_ids;
+    std::vector<BoundingBox> boxes;
+    inference->postprocess_outputs(1.0f, 1.0f, scores, class_ids, boxes);
+
+    // All four clear the threshold; only the two highest-scoring are ranked.
+    EXPECT_EQ(scores.size(), 2u);
+}
+
+TEST_F(PostprocessTest, NegativeMaxDetectionsRejectedAtConstruction) {
+    Config config;
+    config.max_detections = -1;
+
+    auto backend = std::make_unique<MockBackend>();
+    backend->set_outputs({{}, {}}, {{1, 1, 4}, {1, 1, 6}});
+
+    EXPECT_THROW(RFDETRInference(std::move(backend), labels_file_->path(), config), std::invalid_argument);
+}
+
+TEST_F(PostprocessTest, NaNScoreIsDroppedNotKept) {
+    const int num_dets = 1;
+    const int num_classes = 6;
+
+    std::vector<float> dets_data = {0.5f, 0.5f, 0.2f, 0.1f};
+    std::vector<float> labels_data(static_cast<size_t>(num_classes), -10.0f);
+    labels_data[2] = std::numeric_limits<float>::quiet_NaN();
+
+    auto inference =
+        make_inference({dets_data, labels_data}, {{1, num_dets, 4}, {1, num_dets, num_classes}}, 0.5f, 560);
+
+    std::vector<float> scores;
+    std::vector<int> class_ids;
+    std::vector<BoundingBox> boxes;
+    inference->postprocess_outputs(1.0f, 1.0f, scores, class_ids, boxes);
+
+    // A NaN ranks first (as it does in torch's descending sort) but fails the
+    // `score > threshold` test, so it never reaches the output.
+    EXPECT_TRUE(scores.empty());
+}
+
+// --- Background logit slot (rfdetr 1.9.4, PR #1397) -------------------------
+
+TEST_F(PostprocessTest, BackgroundClassIdNoneKeepsEverySlot) {
+    const int num_dets = 1;
+    const int num_classes = 5; // exactly as many slots as the fixture has labels
+
+    Config config;
+    config.resolution = 560;
+    config.threshold = 0.5f;
+    config.background_class_id = std::nullopt;
+
+    std::vector<float> dets_data = {0.5f, 0.5f, 0.2f, 0.1f};
+    std::vector<float> labels_data(static_cast<size_t>(num_classes), -10.0f);
+    labels_data[0] = 10.0f; // slot 0 is a real class when no slot is excluded
+
+    auto inference = make_inference({dets_data, labels_data}, {{1, num_dets, 4}, {1, num_dets, num_classes}}, config);
+
+    std::vector<float> scores;
+    std::vector<int> class_ids;
+    std::vector<BoundingBox> boxes;
+    inference->postprocess_outputs(1.0f, 1.0f, scores, class_ids, boxes);
+
+    ASSERT_EQ(class_ids.size(), 1u);
+    EXPECT_EQ(class_ids[0], 0); // no shift: slot 0 -> "person"
+}
+
+TEST_F(PostprocessTest, BackgroundClassIdCountsFromTheEnd) {
+    const int num_dets = 1;
+    const int num_classes = 6;
+
+    Config config;
+    config.resolution = 560;
+    config.threshold = 0.5f;
+    config.background_class_id = -1; // upstream's own default: final slot
+
+    std::vector<float> dets_data = {0.5f, 0.5f, 0.2f, 0.1f};
+    std::vector<float> labels_data(static_cast<size_t>(num_classes), -10.0f);
+    labels_data[0] = 10.0f;               // now a foreground slot -> label 0
+    labels_data[num_classes - 1] = 20.0f; // excluded as background
+
+    auto inference = make_inference({dets_data, labels_data}, {{1, num_dets, 4}, {1, num_dets, num_classes}}, config);
+
+    std::vector<float> scores;
+    std::vector<int> class_ids;
+    std::vector<BoundingBox> boxes;
+    inference->postprocess_outputs(1.0f, 1.0f, scores, class_ids, boxes);
+
+    ASSERT_EQ(class_ids.size(), 1u);
+    EXPECT_EQ(class_ids[0], 0);
+}
+
+TEST_F(PostprocessTest, BackgroundClassIdOutOfRangeRejected) {
+    const int num_dets = 1;
+    const int num_classes = 6;
+
+    Config config;
+    config.resolution = 560;
+    config.background_class_id = num_classes; // one past the last slot
+
+    std::vector<float> dets_data = {0.5f, 0.5f, 0.2f, 0.1f};
+    std::vector<float> labels_data(static_cast<size_t>(num_classes), -10.0f);
+
+    auto inference = make_inference({dets_data, labels_data}, {{1, num_dets, 4}, {1, num_dets, num_classes}}, config);
+
+    std::vector<float> scores;
+    std::vector<int> class_ids;
+    std::vector<BoundingBox> boxes;
+    EXPECT_THROW(inference->postprocess_outputs(1.0f, 1.0f, scores, class_ids, boxes), std::invalid_argument);
+}
+
+// --- Segmentation shares the detection path's selection --------------------
+
+TEST_F(PostprocessTest, SegmentationRanksFlattenedQueryClassPairs) {
+    const int num_dets = 1;
+    const int num_classes = 6;
+    const int mask_h = 2;
+    const int mask_w = 2;
+
+    std::vector<float> dets_data = {0.5f, 0.5f, 0.2f, 0.1f};
+
+    std::vector<float> labels_data(static_cast<size_t>(num_classes), -10.0f);
+    labels_data[1] = 4.0f; // -> label 0
+    labels_data[3] = 6.0f; // -> label 2
+
+    // One mask per query, positive everywhere so the whole frame is foreground.
+    std::vector<float> masks_data(static_cast<size_t>(mask_h * mask_w), 1.0f);
+
+    auto inference =
+        make_inference({dets_data, labels_data, masks_data},
+                       {{1, num_dets, 4}, {1, num_dets, num_classes}, {1, num_dets, mask_h, mask_w}}, 0.5f, 560);
+
+    std::vector<float> scores;
+    std::vector<int> class_ids;
+    std::vector<BoundingBox> boxes;
+    std::vector<rfdetr::media::Mask> masks;
+    inference->postprocess_segmentation_outputs(1.0f, 1.0f, 4, 4, scores, class_ids, boxes, masks);
+
+    // Both classes of the single query survive, strongest first, each carrying
+    // its own copy of that query's mask.
+    ASSERT_EQ(class_ids.size(), 2u);
+    EXPECT_EQ(class_ids[0], 2);
+    EXPECT_EQ(class_ids[1], 0);
+    ASSERT_EQ(masks.size(), 2u);
+    EXPECT_EQ(masks[0].data, masks[1].data);
 }
 
 // ============================================================================


### PR DESCRIPTION
Continues the 1.9.2 alignment, which correctly found nothing for C++ to do. 1.9.3 and 1.9.4 are different: two changes land on the decode contract, and both were wrong here in the same way they were wrong upstream.

Multi-label selection (1.9.3, PR #1320). Class scores are independent sigmoids, so one query can clear the threshold on several classes at once. The detection and keypoint paths took a per-query argmax and kept only the strongest, silently dropping the rest -- the same bug upstream fixed in its own ONNX/TFLite decoders. All three heads now rank the flattened (query, class) grid as PostProcess._select_topk does, in descending score with ties broken by ascending flattened index, and honour max_detections as the ranking cap. Segmentation now excludes the background column before ranking rather than skipping it afterwards, where it consumed cap slots.

Explicit background slot (1.9.4, PR #1397). Config::background_class_id and --background-class-id replace the hardcoded slot-0 assumption. The default 0 preserves the shipped exports' layout (logit n is COCO category n, which is how data/coco-labels-91.txt is indexed), so decoded labels do not move. Upstream's own -1 default would mis-decode those same weights.

Also fixed along the way: a NaN score passed !(score <= threshold) and was emitted as a detection with NaN confidence, and the segmentation ranking comparator was not a strict weak ordering when any score was NaN -- undefined behaviour in std::partial_sort.

Selection logic is shared by all three CPU heads and the CUDA kernels (src/processing_utils.cpp, mirroring upstream's export/_topk.py and export/_class_layout.py), per the mission.md commitment that the CPU and GPU postprocessors are two implementations of one contract.

AGENTS.md gains a mandatory fetch-before-work rule. This pass was written against a develop four commits stale, so it missed the completed 1.9.2 alignment, the specs/ tree, and the rfdetr-alignment skill governing the task. The spec triple under specs/features/ was therefore written after the implementation rather than before it; its requirements.md says so.

Verified: 52/52 unit tests on ONNX Runtime, 62/62 on TensorRT+CUDA including the 6 CPU/GPU segmentation parity tests (RTX 3060, TensorRT 10.13.3.9). clang-format and cppcheck clean. Not re-exported end to end against a real 1.9.4 model, and clang-tidy not run -- both recorded in validation.md.


Claude-Session: https://claude.ai/code/session_01BzwxLh3tW5iL99aQuC27Jt