### PR TITLE
chore: add scripts/run_gate.sh, an unattended gpu-verify driver

### DIFF
--- a/.claude/skills/gpu-verify/SKILL.md
+++ b/.claude/skills/gpu-verify/SKILL.md
@@ -20,6 +20,10 @@ Written for any coding agent; every step is a shell command a human can run.
 - Checked-in `.dali` pipelines exist for resolutions **432** and **576** only; anything else needs
   `./scripts/generate_dali_pipelines.sh <res>` with `--gpus all` Docker
 
+On rented hardware, `./scripts/run_gate.sh` drives steps 1, 2, 4, 5 and 6 below unattended and
+reports the rest as `UNRUN`. Renting, preparing and collecting:
+[docs/rented-gpu-runbook.md](../../../docs/rented-gpu-runbook.md).
+
 ## 1. Build the matrix
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ The `executorch` variant builds the ExecuTorch runtime from source into `/opt/ex
 - Runtime flags (default off): `--gpu-preprocess`, `--gpu-postprocess` (segmentation only), `--dali-pipeline-dir <dir>` (default `data/dali`)
 - Regenerate `.dali` pipelines for a new resolution: `./scripts/generate_dali_pipelines.sh <res>` (needs `--gpus all` Docker); 432 and 576 are checked in
 - GPU unit tests (`test_gpu_postprocess.cpp`) `GTEST_SKIP()` without a CUDA device; like TensorRT, CI compiles but does not execute GPU paths — test manually with [gpu-verify](.claude/skills/gpu-verify/SKILL.md)
-- On a rented GPU box, `./scripts/run_gate.sh` drives the executable part of that checklist unattended and reports the rest as `UNRUN`; it arms a deadline watchdog and stops the instance when done. Env knobs: `CUDA_ARCH` (default `89`), `DEADLINE_HOURS`, `SKIP_DEFAULT_PATH`, `SELF_STOP`, `MODEL`, `VIDEO`
+- On a rented GPU box, `./scripts/run_gate.sh` drives the executable part of that checklist unattended and reports the rest as `UNRUN`; it arms a deadline watchdog and stops the instance when done. Env knobs: `CUDA_ARCH` (default `89`), `DEADLINE_HOURS`, `SKIP_DEFAULT_PATH`, `SELF_STOP`, `MODEL`, `VIDEO`. End-to-end procedure — choosing an instance, export prep, setup script, collecting results: [docs/rented-gpu-runbook.md](docs/rented-gpu-runbook.md)
 - Design constraints: [specs/gpu-pipeline.md](specs/gpu-pipeline.md) — remaining phases: [specs/roadmap.md](specs/roadmap.md)
 
 ## Dependency Resolution

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ The `executorch` variant builds the ExecuTorch runtime from source into `/opt/ex
 - Runtime flags (default off): `--gpu-preprocess`, `--gpu-postprocess` (segmentation only), `--dali-pipeline-dir <dir>` (default `data/dali`)
 - Regenerate `.dali` pipelines for a new resolution: `./scripts/generate_dali_pipelines.sh <res>` (needs `--gpus all` Docker); 432 and 576 are checked in
 - GPU unit tests (`test_gpu_postprocess.cpp`) `GTEST_SKIP()` without a CUDA device; like TensorRT, CI compiles but does not execute GPU paths — test manually with [gpu-verify](.claude/skills/gpu-verify/SKILL.md)
+- On a rented GPU box, `./scripts/run_gate.sh` drives the executable part of that checklist unattended and reports the rest as `UNRUN`; it arms a deadline watchdog and stops the instance when done. Env knobs: `CUDA_ARCH` (default `89`), `DEADLINE_HOURS`, `SKIP_DEFAULT_PATH`, `SELF_STOP`, `MODEL`, `VIDEO`
 - Design constraints: [specs/gpu-pipeline.md](specs/gpu-pipeline.md) — remaining phases: [specs/roadmap.md](specs/roadmap.md)
 
 ## Dependency Resolution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ upstream `rfdetr` releases it is kept in step with.
 
 ## [Unreleased]
 
+### Tooling: `scripts/run_gate.sh`, an unattended driver for the gpu-verify gate
+
+The [gpu-verify](.claude/skills/gpu-verify/SKILL.md) checklist is the only thing standing between
+the TensorRT, DALI and CUDA paths and an unverified release, and running it means renting a GPU by
+the hour. Two things made that awkward in practice: the checklist is a document, so every run was
+hand-driven from an SSH session that dies when the laptop closes, and a hung or finished run keeps
+billing until someone notices. This turns the executable part into one script.
+
+What it does not do is the point. `tests/data/gpu_parity/` does not exist and `src/main.cpp` has no
+output-path flag — roadmap Phases 2 and 1 respectively — so the numeric tolerances the gate is
+actually built around (preprocessed tensor `max |Δ| ≤ 2e-2`, scores within `1e-3`, box centres
+within 1 px, mask IoU ≥ 0.999) have nothing to run against. The script reports those as `UNRUN`
+rather than skipping them silently, and the four combinations it *can* run are labelled smoke
+tests, not parity checks. That follows the skill's own rule: an unrun check is reported as unrun,
+never implied to have passed. Running this script is not passing the gate; Phase 2 still gates
+Phase 4.
+
+| File | Change |
+|------|--------|
+| `scripts/run_gate.sh` | New. Drives step 1 (full TensorRT+DALI+CUDA build, both halves independently, and the two `USE_DALI`/`USE_CUDA_POSTPROCESS` + ONNX Runtime configure guards that must `FATAL_ERROR`), step 2 as smoke runs, step 4 (`compute-sanitizer` memcheck over a long video), step 5 (benchmarks), and step 6 (default ONNX Runtime build + UnitTests). Writes a `PASS`/`FAIL`/`UNRUN` summary plus per-check output into `~/gate-results/` for the CHANGELOG entry step 7 asks for. Not `set -e`: a failing check is data, so the remaining checks still run. |
+| `scripts/run_gate.sh` | Cost control, because the gate runs on metered hardware. A `systemd-run` deadline watchdog fires `brev stop` after `DEADLINE_HOURS` whether the run finished, crashed, or hung — the self-stop at the end only covers the clean path. `SKIP_DEFAULT_PATH=1` moves step 6, which needs no GPU, back to a local machine and off the metered clock. `CUDA_ARCH` defaults to `89` (L4/L40S/RTX-Ada) rather than the CMake default `86`, since the arch is a property of the rented box, not the project. |
+| `AGENTS.md` | One line under "GPU Pipeline" pointing at the script and its env knobs, alongside the existing `fetch_dali.sh` and `generate_dali_pipelines.sh` entries. |
+
+Two checks are untestable from the script by construction and say so: the `GTEST_SKIP()`-without-a-
+device behaviour needs a machine with no CUDA device, and the guest-shutdown watchdog fallback
+needs one manual confirmation on the provider console that a halted VM bills as *stopped* rather
+than billed-but-off.
+
+No `specs/features/` directory: per [AGENTS.md](AGENTS.md), a spec is required for a roadmap phase,
+a release, an rfdetr alignment, or a change to a path CI cannot execute. This adds a helper script
+and touches none of `src/`, so it is CHANGELOG-only. No README change either — it alters no code,
+build option, backend version, Docker image, or export package.
+
+
 ### Workflow: spec-driven development loop, four skills, roadmap split
 
 Second pass over the agent workflow, reviewing the previous `specs/` change against the reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,81 @@ is on the record; these predate it.
 
 ---
 
+### GPU gate: first execution of `run_gate.sh` against real hardware
+
+The [gpu-verify](.claude/skills/gpu-verify/SKILL.md) gate had never been run — the script's own
+header said so ("no execution history against real hardware"). Running it on a local RTX 3060
+Laptop, following [docs/rented-gpu-runbook.md](docs/rented-gpu-runbook.md), took six fixes before
+it produced a usable result. Two of them are bugs anyone would have hit; four are in the script.
+
+#### Result
+
+Hardware and versions from `gate-results/environment.txt`, per gate step 7:
+
+| | |
+|---|---|
+| GPU / driver | NVIDIA GeForce RTX 3060 Laptop, 6 GB, driver 580.173.02 |
+| CUDA | `nvcc` 12.0.140 (Ubuntu `nvidia-cuda-toolkit`); driver reports CUDA 13.0 |
+| TensorRT | 10.13.3.9, `Linux.x86_64-gnu.cuda-12.9` tarball via `TENSORRT_ROOTDIR` |
+| DALI | staged from `nvcr.io/nvidia/tritonserver:25.12-py3` |
+| Model | `rfdetr-seg-medium.onnx`, rfdetr 1.9.4, 432×432 |
+| `CMAKE_CUDA_ARCHITECTURES` | 86 |
+
+**9 PASS, 0 FAIL, 5 UNRUN.** Passing: the full TensorRT + DALI + CUDA build, `USE_DALI=ON` alone,
+`USE_CUDA_POSTPROCESS=ON` alone, both configure-time guards rejecting the ONNX Runtime combination,
+all four pre/post combinations as smoke runs, and benchmarks.
+
+Unrun, stated plainly as unrun rather than implied to have passed:
+
+- The parity tolerances (tensor 2e-2, scores 1e-3, box centres 1 px, mask IoU 0.999) — no
+  `tests/data/gpu_parity/`, roadmap Phase 2.
+- The dense >100-detection fixture — roadmap Phase 2.
+- The per-stage four-combination benchmark — `bench_gpu_pipeline.cpp` does not exist, Phase 2.
+- **`compute-sanitizer` over 1000 frames** — the box's sanitizer (CUDA 12.0, Jan 2023) cannot
+  instrument the app. The `daliOutputRelease` ordering check the pipeline spec calls for is
+  therefore still unperformed; a passing smoke run is not a substitute for it.
+- Gate step 6 on the GPU box — run locally instead, where it passed.
+
+Also unrun and not attempted: `-DWERROR=ON`. See Known Issues.
+
+#### What the four combinations showed
+
+Not a parity check — one image, final scores rather than the preprocessed tensor — but the first
+real signal on the question Phase 2 exists to answer:
+
+| Combination | bicycle | dog | car | motorbike |
+|---|---|---|---|---|
+| cpu-cpu | 0.952574 | 0.891811 | 0.816406 | 0.580352 |
+| cpupre-gpupost | 0.952574 | 0.891811 | 0.816406 | 0.580352 |
+| gpupre-cpupost | 0.956145 | 0.888372 | 0.800068 | 0.571767 |
+| gpupre-gpupost | 0.956145 | 0.888372 | 0.800068 | 0.571767 |
+
+They split by **preprocessing**, not postprocessing. CUDA postprocessing is bit-identical to the CPU
+path on real hardware — the `src/gpu/` correctness rule holding outside `test_gpu_postprocess.cpp`
+for the first time. DALI preprocessing is not: max score delta 0.0163 on `car`, **16× the gate's
+1e-3 score tolerance**. Phase 2 should be written expecting to find a discrepancy, not to confirm
+its absence.
+
+#### Fixed
+
+| File | Change |
+|------|--------|
+| `cmake/deps/packages/TensorRT.cmake` | The pinned download URL was a hard 404: `...Linux.x86_64.gnu.cuda-13.0.tar.gz`, where NVIDIA's path is `x86_64-gnu`. This blocked `-DUSE_TENSORRT=ON` from a clean tree for everyone, including the runbook's own provisioning script, which installs only the CUDA toolkit and lets CMake fetch TensorRT. Undetected because CI never builds this backend. |
+| `scripts/run_gate.sh` | `arm_watchdog()` falls back to `sudo shutdown -h "+N"` when no `brev` CLI is present, so running the gate on a local machine would halt it — `SELF_STOP` does not cover that path. New `WATCHDOG` variable (default `1`, rented behaviour unchanged) skips arming it. |
+| `scripts/run_gate.sh` | Exports the TensorRT lib directory on `LD_LIBRARY_PATH`. `libnvinfer` dlopens `libnvinfer_builder_resource.so` at engine-build time, and a dlopen from inside a dependency does not use the executable's `RUNPATH`, so every combination died with `Unable to load library` before building an engine. Covers both an existing prefix and the tarball `cmake/deps` downloads into `build-gpu/_deps`. |
+| `scripts/run_gate.sh` | `probe_tensorrt()` read `$3` of `#define NV_TENSORRT_MAJOR`, which in TensorRT 10.x expands to `TRT_MAJOR_ENTERPRISE`, not a literal — so `environment.txt`, the file step 7 says to copy into this changelog, recorded `TensorRT TRT_MAJOR_ENTERPRISE.TRT_MINOR_ENTERPRISE...`. Now resolves one level of indirection. |
+| `scripts/run_gate.sh` | New `EXTRA_CMAKE_ARGS`, appended to the four TensorRT configures and deliberately not to the ONNX Runtime one. A box with its own TensorRT needs `-DTENSORRT_ROOTDIR=<prefix>`, which `ProvidedPackageManager.cmake` reads as a CMake variable, not an environment variable. `TRT_PREFIX` derives one prefix from either source for both the loader path and the version probe. |
+| `scripts/run_gate.sh` | `step_sanitizer()` treated "no `ERROR SUMMARY: 0` line" as findings, so a sanitizer that never attached was reported `FAIL` — the same column as a real memory error. A tool that could not instrument the app is now `UNRUN`. |
+
+#### Not fixed
+
+`environment.txt` also showed the app's `RUNPATH` carrying raw link items —
+`/usr/lib/x86_64-linux-gnu/libcudart_static.a:Threads::Threads:dl:` — which means unresolved link
+targets are reaching the RPATH computation in the TensorRT build. Harmless here, recorded rather
+than chased.
+
+---
+
 ### Tooling: `scripts/run_gate.sh`, an unattended driver for the gpu-verify gate
 
 The [gpu-verify](.claude/skills/gpu-verify/SKILL.md) checklist is the only thing standing between
@@ -356,6 +431,7 @@ compressed bytes) and frees the video pipeline's preprocess thread.
 
 | Area | Issue |
 |------|-------|
+| `src/backends/tensorrt_backend.cpp` | **Does not compile under `-DWERROR=ON`**, which is what the gpu-verify gate builds with — so gate step 1 fails outright and every later step is skipped. Nine errors on TensorRT 10.13.3.9: `-Wsign-conversion` at lines 148, 161, 257, 267 and 271; `-Wunused-parameter` on `input_shape` at 171; and `-Wdeprecated-declarations` for `NetworkDefinitionCreationFlag::kEXPLICIT_BATCH` (180), `IBuilder::platformHasFastFp16()` (223) and `BuilderFlag::kFP16` (224). The conversions and the unused parameter are mechanical; the deprecations are a real API migration — `kEXPLICIT_BATCH` is a no-op in TensorRT 10 and the FP16 flags are superseded by strongly-typed networks — so per `AGENTS.md` this needs a spec directory before it is touched. CI compiles only the ONNX Runtime lane, which is why strict warnings never reached this file. The gate results above were obtained with `-DWERROR=OFF`. |
 | `src/rfdetr_inference.hpp`, `src/main.cpp` | **Keypoint models exported with `rfdetr` 1.8.2 or later do not decode.** Upstream 1.8.2 changed the default keypoint schema from background-first `[0, 17]` to active-first `[17]` ([#1160](https://github.com/roboflow/rf-detr/pull/1160)); `Config::keypoint_counts` still defaults to `{0, 17}` and there is no CLI override, so the schema can only be changed by editing `Config` and rebuilding. `deploy/requirements.txt` pins `rfdetr[onnx]==1.9.4`, so `deploy/export_keypoint.py` as documented produces the new schema. Expected effect, derived from the release notes and the code rather than observed against an export: the `keypoints` tensor carries one class instead of two, so `postprocess_keypoint_outputs()` raises `Keypoint tensor channels (17) not divisible by number of keypoint classes (2)`; if the `labels` tensor also drops to a single column, `background_class_id`'s default `0` leaves no foreground column and every frame yields zero detections (guarded, not undefined — `build_foreground_scores()` returns empty for a non-positive foreground count). Not yet verified against a real 1.8.2+ keypoint export, and not yet fixed: the choice between a `--keypoint-counts` flag and auto-detecting the schema from the tensor shape needs a model to test against. Pre-1.8.2 exports are unaffected. |
 | `deploy/export_executorch.py` | Cannot export segmentation models: `--model_type` offers only the detection classes and the script instantiates `RFDETRNano`…`RFDETR2XLarge`, never `RFDETRSeg*`. Not an upstream or runtime limitation — `rfdetr` 1.9.0 exports `RFDETRSegMedium` to `.pte` without error, `ExecuTorchBackend::validate_output_order()` inspects only outputs 0 and 1 so a third `masks` output passes, and `postprocess_segmentation_outputs()` addresses outputs positionally. Segmentation `.pte` files must currently be exported by hand; see [docs/backend-parity-segmentation-video.md](docs/backend-parity-segmentation-video.md). |
 | `src/main.cpp` | Video output is hard-coded to `output_video.mp4` in the current working directory with no override flag, so comparing backends requires running each from its own directory. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,7 +311,7 @@ Phase 4.
 | File | Change |
 |------|--------|
 | `scripts/run_gate.sh` | New. Drives step 1 (full TensorRT+DALI+CUDA build, both halves independently, and the two `USE_DALI`/`USE_CUDA_POSTPROCESS` + ONNX Runtime configure guards that must `FATAL_ERROR`), step 2 as smoke runs, step 4 (`compute-sanitizer` memcheck over a long video), step 5 (benchmarks), and step 6 (default ONNX Runtime build + UnitTests). Writes a `PASS`/`FAIL`/`UNRUN` summary plus per-check output into `~/gate-results/` for the CHANGELOG entry step 7 asks for. Not `set -e`: a failing check is data, so the remaining checks still run. |
-| `scripts/run_gate.sh` | Cost control, because the gate runs on metered hardware. A `systemd-run` deadline watchdog fires `brev stop` after `DEADLINE_HOURS` whether the run finished, crashed, or hung — the self-stop at the end only covers the clean path. `SKIP_DEFAULT_PATH=1` moves step 6, which needs no GPU, back to a local machine and off the metered clock. `CUDA_ARCH` defaults to `89` (L4/L40S/RTX-Ada) rather than the CMake default `86`, since the arch is a property of the rented box, not the project. |
+| `scripts/run_gate.sh` | Cost control, because the gate runs on metered hardware. A `systemd-run` deadline watchdog fires `brev stop` after `DEADLINE_HOURS` whether the run finished, crashed, or hung — the self-stop at the end only covers the clean path. `SKIP_DEFAULT_PATH=1` moves step 6's default ONNX Runtime build, which needs no GPU, back to a local machine and off the metered clock. `CUDA_ARCH` defaults to `89` (L4/L40S/RTX-Ada) rather than the CMake default `86`, since the arch is a property of the rented box, not the project. |
 | `docs/rented-gpu-runbook.md` | New. The operational half the skill deliberately leaves out: how to choose an instance, what to prepare at home before the meter starts, the provisioning setup script, running under `tmux`, and collecting results. Leads with what a rented hour actually buys today — steps 1, 2 (smoke), 4 and 5 — so nobody reads a green summary as a passed gate. Records the selection rule the hard way round: this workload is build-bound, so rank instances by CPU count and provisioning time, not VRAM, and avoid `highcpu`-class families whose ~0.9 GB per vCPU will OOM-kill a parallel C++ build on a swapless cloud VM. |
 | `AGENTS.md`, `.claude/skills/gpu-verify/SKILL.md` | Pointers to the script and the runbook, alongside the existing `fetch_dali.sh` and `generate_dali_pipelines.sh` entries. |
 
@@ -331,6 +331,17 @@ Two checks are untestable from the script by construction and say so: the `GTEST
 device behaviour needs a machine with no CUDA device, and the guest-shutdown watchdog fallback
 needs one manual confirmation on the provider console that a halted VM bills as *stopped* rather
 than billed-but-off.
+
+Three review findings on the gate driver were fixed before it ran again; all three would have shown
+up as a green summary hiding an unrun check, which is the one failure mode a gate cannot have.
+
+| File | Change |
+|------|--------|
+| `scripts/run_gate.sh` | The `compute-sanitizer` step now requires the run to *finish*. It discarded the exit status and judged on the summary line alone, so an app that died in the first second — a `MODEL` path that does not exist, a video the decoder rejects — still printed `ERROR SUMMARY: 0 errors` and was recorded `PASS` for a 1000-frame run that never happened. `MODEL` is now `-f`-checked here as it already was in step 2, the exit status is captured, and the not-instrumented branch is tested first so a toolkit/driver mismatch stays `UNRUN` rather than being reclassified `FAIL` by its non-zero status. |
+| `scripts/run_gate.sh` | The zero-findings match is anchored to `ERROR SUMMARY: 0 errors`. The old pattern also matched `0 errors` as a substring, so `ERROR SUMMARY: 10 errors` — or 20, or 100 — passed. |
+| `scripts/run_gate.sh` | `SKIP_DEFAULT_PATH=1` no longer suppresses the GPU build's UnitTests. The early return sat above them, so the documented way to move the CPU build off the metered clock also skipped `test_gpu_postprocess` — the one test that needs the rented device to run rather than `GTEST_SKIP()`, and the reason the script is on a GPU box at all. |
+| `scripts/run_gate.sh` | Step 6 reports the bit-identical baseline comparison as `UNRUN`. A green default build and green UnitTests are not the checklist's first step-6 box, which asks for output bit-identical to the pre-change baseline; that needs an inference run and a baseline to diff against, and `src/main.cpp` still has no output-path flag (Phase 1). It was previously absorbed into the `PASS`. |
+| `scripts/run_gate.sh` | `step_build` returns explicitly. Its status on the success path was whatever the trailing guard loop's `rm -rf` left, and `main()` reads it to decide whether steps 2–5 have a binary to run. |
 
 No `specs/features/` directory: per [AGENTS.md](AGENTS.md), a spec is required for a roadmap phase,
 a release, an rfdetr alignment, or a change to a path CI cannot execute. This adds a helper script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,20 @@ Phase 4.
 |------|--------|
 | `scripts/run_gate.sh` | New. Drives step 1 (full TensorRT+DALI+CUDA build, both halves independently, and the two `USE_DALI`/`USE_CUDA_POSTPROCESS` + ONNX Runtime configure guards that must `FATAL_ERROR`), step 2 as smoke runs, step 4 (`compute-sanitizer` memcheck over a long video), step 5 (benchmarks), and step 6 (default ONNX Runtime build + UnitTests). Writes a `PASS`/`FAIL`/`UNRUN` summary plus per-check output into `~/gate-results/` for the CHANGELOG entry step 7 asks for. Not `set -e`: a failing check is data, so the remaining checks still run. |
 | `scripts/run_gate.sh` | Cost control, because the gate runs on metered hardware. A `systemd-run` deadline watchdog fires `brev stop` after `DEADLINE_HOURS` whether the run finished, crashed, or hung — the self-stop at the end only covers the clean path. `SKIP_DEFAULT_PATH=1` moves step 6, which needs no GPU, back to a local machine and off the metered clock. `CUDA_ARCH` defaults to `89` (L4/L40S/RTX-Ada) rather than the CMake default `86`, since the arch is a property of the rented box, not the project. |
-| `AGENTS.md` | One line under "GPU Pipeline" pointing at the script and its env knobs, alongside the existing `fetch_dali.sh` and `generate_dali_pipelines.sh` entries. |
+| `docs/rented-gpu-runbook.md` | New. The operational half the skill deliberately leaves out: how to choose an instance, what to prepare at home before the meter starts, the provisioning setup script, running under `tmux`, and collecting results. Leads with what a rented hour actually buys today — steps 1, 2 (smoke), 4 and 5 — so nobody reads a green summary as a passed gate. Records the selection rule the hard way round: this workload is build-bound, so rank instances by CPU count and provisioning time, not VRAM, and avoid `highcpu`-class families whose ~0.9 GB per vCPU will OOM-kill a parallel C++ build on a swapless cloud VM. |
+| `AGENTS.md`, `.claude/skills/gpu-verify/SKILL.md` | Pointers to the script and the runbook, alongside the existing `fetch_dali.sh` and `generate_dali_pipelines.sh` entries. |
+
+The version probes behind step 7 are the part most likely to be quietly useless, so they were
+written against how this project actually resolves its dependencies rather than against convention.
+TensorRT is normally *not* a system package here — `cmake/deps/packages/TensorRT.cmake` downloads
+the pinned tarball into `${CMAKE_BINARY_DIR}/_deps` — so a probe reading `/usr/include` finds
+nothing on a correct build. `probe_tensorrt` searches the build trees, then `TENSORRT_ROOTDIR`,
+then the system paths, and reads the version from the `NV_TENSORRT_*` macros rather than parsing
+the extracted directory name, which can drift from the pin. It runs *after* step 1, since that
+configure is what performs the download. DALI ships no version header in the extracted wheel, so
+`probe_dali` records the provenance that does identify it: the Triton image pinned in
+`fetch_dali.sh`, read out of that script so the two cannot disagree. Both probes were exercised
+against a synthetic tree, present and absent.
 
 Two checks are untestable from the script by construction and say so: the `GTEST_SKIP()`-without-a-
 device behaviour needs a machine with no CUDA device, and the guest-shutdown watchdog fallback
@@ -38,7 +51,8 @@ than billed-but-off.
 No `specs/features/` directory: per [AGENTS.md](AGENTS.md), a spec is required for a roadmap phase,
 a release, an rfdetr alignment, or a change to a path CI cannot execute. This adds a helper script
 and touches none of `src/`, so it is CHANGELOG-only. No README change either — it alters no code,
-build option, backend version, Docker image, or export package.
+build option, backend version, Docker image, or export package; `docs/rented-gpu-runbook.md` is
+reached from `AGENTS.md` and the skill, which is where someone running the gate is already looking.
 
 
 ### Workflow: spec-driven development loop, four skills, roadmap split

--- a/cmake/deps/packages/TensorRT.cmake
+++ b/cmake/deps/packages/TensorRT.cmake
@@ -5,7 +5,7 @@ deps_declare(TensorRT
     CONAN                 "tensorrt/10.13.3"
     VCPKG                 "tensorrt"
     PROVIDED_ACQUIRE      DOWNLOAD
-    PROVIDED_URL          "https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.13.3/tars/TensorRT-10.13.3.9.Linux.x86_64.gnu.cuda-13.0.tar.gz"
+    PROVIDED_URL          "https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/10.13.3/tars/TensorRT-10.13.3.9.Linux.x86_64-gnu.cuda-13.0.tar.gz"
     PROVIDED_VERSION      "10.13.3.9"
     PROVIDED_SUBDIR       "TensorRT-10.13.3.9"
     PROVIDED_INCLUDE      "include"

--- a/docs/rented-gpu-runbook.md
+++ b/docs/rented-gpu-runbook.md
@@ -177,6 +177,8 @@ VIDEO=~/long.mp4 \
 | `DEADLINE_HOURS` | `6` | Watchdog fires `brev stop` after this, run finished or not |
 | `SKIP_DEFAULT_PATH` | `0` | `1` skips step 6, which needs no GPU |
 | `SELF_STOP` | `1` | `0` leaves the instance up after a clean finish |
+| `WATCHDOG` | `1` | `0` does not arm the watchdog at all. **Set this when running at home** — without a `brev` CLI the watchdog falls back to `sudo shutdown -h`, which halts your own machine |
+| `EXTRA_CMAKE_ARGS` | *(empty)* | Extra `-D` flags for the four TensorRT configures, e.g. `-DTENSORRT_ROOTDIR=<prefix>` on a box that already has TensorRT |
 | `REPO`, `DALI_ROOT`, `RESULTS` | derived / `~/dependencies/dali` / `~/gate-results` | Paths |
 
 ### Protecting a one-hour budget
@@ -209,8 +211,15 @@ plainly as unrun**. An unrun check is reported as unrun, never implied to have p
 
 ## Known rough edges
 
-- The script has **no execution history against real hardware**. Budget a few minutes on the first
-  run for a wrong path.
+- First run against real hardware was 2026-08-26 on an RTX 3060 Laptop; see `CHANGELOG.md` for the
+  result and the six fixes it took to get there. It is no longer untried, but it has been tried
+  exactly once, on one card, with `-DWERROR=OFF`.
+- `src/backends/tensorrt_backend.cpp` does **not** compile under `-DWERROR=ON`, which step 1 uses.
+  Until that is fixed (roadmap Phase 1), a full gate run needs `EXTRA_CMAKE_ARGS="-DWERROR=OFF"`,
+  and the result must say so.
+- `compute-sanitizer` must match the driver. A toolkit older than the driver's CUDA version may
+  fail to attach at all; the script now reports that as `UNRUN` rather than `FAIL`, but the
+  `daliOutputRelease` ordering check is then simply not done.
 - The `GTEST_SKIP()`-without-a-device check is untestable on a GPU box by construction. Verify it on
   a CPU-only host.
 - `probe_tensorrt` searches `build-*/_deps/TensorRT-*/`, then `TENSORRT_ROOTDIR`, then the system

--- a/docs/rented-gpu-runbook.md
+++ b/docs/rented-gpu-runbook.md
@@ -1,0 +1,218 @@
+# Running the GPU Gate on a Rented GPU
+
+CI runners have no GPU, so the TensorRT, DALI and CUDA paths are verified by hand via
+[gpu-verify](../.claude/skills/gpu-verify/SKILL.md). This document is the operational half: how to
+rent a machine, run [`scripts/run_gate.sh`](../scripts/run_gate.sh) on it unattended, and not leave
+it billing.
+
+The skill says *what* to check and to which tolerances. This says *how to get a box that can check
+it*.
+
+---
+
+## What a rented hour actually buys you today
+
+**Running `run_gate.sh` is not passing the gate.** `tests/data/gpu_parity/` does not exist and
+`src/main.cpp` has no output-path flag — roadmap Phases 2 and 1 — so the tolerances the gate is
+built around (preprocessed tensor `max |Δ| ≤ 2e-2`, scores within `1e-3`, box centres within 1 px,
+mask IoU ≥ 0.999) have nothing to compare against. The script reports them `UNRUN`.
+
+| Gate step | On a rented box today |
+|-----------|-----------------------|
+| 1 — build matrix and configure guards | Fully runnable |
+| 2 — four pre/post combinations | Smoke runs only; no tolerance check |
+| 3 — dense fixture | `UNRUN`, Phase 2 |
+| 4 — `compute-sanitizer` over 1000 frames | Fully runnable |
+| 5 — benchmarks | `benchmarks` runs; the per-stage four-combination benchmark is Phase 2 |
+| 6 — default CPU path unchanged | Fully runnable, but needs no GPU — do it at home |
+
+**Phase 2 is CPU work you can do locally for free, and it is what makes a rented hour worth
+buying.** Doing it first is the difference between closing the gate and paying for four smoke tests.
+
+---
+
+## Choosing an instance
+
+The workload is **build-bound, not GPU-bound**: five CMake configure-and-build cycles dominate the
+clock and the GPU is idle for most of them. Pick on cores, not VRAM. Any modern card has ample
+memory for RF-DETR at 432.
+
+Priorities, in order:
+
+1. **CPU count.** Five builds on 8 cores is ~30 min; on 128 cores it is ~4.
+2. **Provisioning time.** Some providers are ready in 1 minute, others 7. That is 10% of a one-hour
+   budget.
+3. **Stop/start**, if you plan to spread the work over several sittings rather than one run.
+4. **Disk.** `scripts/fetch_dali.sh` pulls a ~25 GB Triton image to extract ~1 GB of DALI. 100 GB
+   works; more is comfortable.
+5. **VRAM and GPU class.** Last. 16 GB is already plenty.
+
+Set `CUDA_ARCH` to match the card — it is a property of the rented box, not of this project:
+
+| Card | `CUDA_ARCH` |
+|------|-------------|
+| L4, L40, L40S, RTX 4000/6000 Ada | `89` |
+| A4000, A5000, A10, A10G, A6000, A40 | `86` |
+| A100 | `80` |
+| T4 | `75` |
+
+**Avoid RAM-starved machine families.** A C++ build with nvcc, TensorRT headers under C++20 and
+OpenCV routinely peaks at 1–2 GB per translation unit. A `highcpu`-class VM at ~0.9 GB per vCPU
+will OOM-kill a parallel build, and cloud VMs generally have no swap. Budget ≥ 2 GB per core.
+
+**Watch the billing model.** Some instances cannot be stopped, only deleted — for those the clock
+runs from deploy to delete, so do every bit of preparation before you press Deploy. Where credits
+rather than a card fund the account, an exhausted balance may delete the instance *and its disk*;
+copy results off as you go rather than at the end.
+
+---
+
+## Part 1 — At home, before renting (free)
+
+### 1. Export a segmentation model at 432
+
+Both details matter: `--gpu-postprocess` requires `--segmentation`, and only **432** and **576**
+have checked-in `.dali` pipelines. Anything else needs
+`./scripts/generate_dali_pipelines.sh <res>` and a `--gpus all` Docker host.
+
+```bash
+python3.11 -m venv rfdetr_venv && source rfdetr_venv/bin/activate
+pip install rfdetr[onnx]==1.9.4
+python deploy/export_segmentation.py --model_type medium --input_size 432
+```
+
+See [export.md](export.md) for the full matrix of export options.
+
+### 2. Prepare a video of at least 1000 frames
+
+A single clean short run proves nothing about `daliOutputRelease` ordering — see
+[gpu-pipeline.md](../specs/gpu-pipeline.md).
+
+```bash
+ffmpeg -stream_loop 30 -i clip.mp4 -c copy long.mp4                    # real footage, preferred
+ffmpeg -loop 1 -i data/dog.jpg -t 40 -r 25 -pix_fmt yuv420p long.mp4   # fallback: exactly 1000 frames
+```
+
+### 3. Run gate step 6 locally
+
+It needs no GPU, so paying for it is waste:
+
+```bash
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build --parallel
+ctest --test-dir build --output-on-failure -R UnitTests
+```
+
+Passing here lets you set `SKIP_DEFAULT_PATH=1` on the rented box.
+
+### 4. Install your provider's CLI
+
+`run_gate.sh` uses `brev stop` for both its deadline watchdog and its self-stop. Without a CLI on
+the instance it falls back to `shutdown -h`, and you must confirm once on the provider console that
+a halted VM bills as *stopped* rather than billed-but-off.
+
+---
+
+## Part 2 — Provisioning
+
+Use the provider's setup-script field so the box prepares itself while you do something else.
+**TensorRT is not installed here** — `cmake/deps/packages/TensorRT.cmake` downloads the pinned
+tarball at configure time. You only need the CUDA toolkit, for `nvcc` and `compute-sanitizer`.
+
+```bash
+#!/usr/bin/env bash
+set -euxo pipefail
+
+wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+sudo dpkg -i cuda-keyring_1.1-1_all.deb
+sudo apt-get update
+sudo apt-get install -y cuda-toolkit-13-0 \
+    git ninja-build cmake g++ pkg-config libopencv-dev libgtest-dev tmux rsync
+
+echo 'export PATH=/usr/local/cuda/bin:$PATH' >> ~/.bashrc
+
+git clone https://github.com/olibartfast/rf-detr-cpp-inference.git ~/rfdetr_inference
+cd ~/rfdetr_inference && git checkout develop
+
+# ~25 GB image pulled to extract ~1 GB of DALI. Drop it afterwards.
+./scripts/fetch_dali.sh
+docker image rm nvcr.io/nvidia/tritonserver:25.12-py3 || true
+
+touch ~/SETUP_DONE
+```
+
+---
+
+## Part 3 — Running the gate
+
+Wait for `~/SETUP_DONE`, then push the model and video from your machine:
+
+```bash
+rsync -av output/rfdetr-seg-medium.onnx long.mp4 <instance>:~/
+```
+
+On the box, **inside tmux** — a plain SSH session dies with your laptop lid, and the instance keeps
+billing either way:
+
+```bash
+cd ~/rfdetr_inference
+tmux new -s gate
+
+DEADLINE_HOURS=1 \
+CUDA_ARCH=89 \
+SKIP_DEFAULT_PATH=1 \
+MODEL=~/rfdetr-seg-medium.onnx \
+VIDEO=~/long.mp4 \
+./scripts/run_gate.sh 2>&1 | tee ~/run.log
+```
+
+`Ctrl-b d` detaches; `tmux attach -t gate` resumes from anywhere.
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `MODEL` | *(unset)* | `.onnx` or `.engine`. Steps 2–5 report `UNRUN` without it |
+| `VIDEO` | *(unset)* | ≥ 1000 frames, for `compute-sanitizer` |
+| `CUDA_ARCH` | `89` | `CMAKE_CUDA_ARCHITECTURES` for the rented card |
+| `DEADLINE_HOURS` | `6` | Watchdog fires `brev stop` after this, run finished or not |
+| `SKIP_DEFAULT_PATH` | `0` | `1` skips step 6, which needs no GPU |
+| `SELF_STOP` | `1` | `0` leaves the instance up after a clean finish |
+| `REPO`, `DALI_ROOT`, `RESULTS` | derived / `~/dependencies/dali` / `~/gate-results` | Paths |
+
+### Protecting a one-hour budget
+
+`compute-sanitizer` under memcheck runs 10–50× slower than native, so a 1000-frame run is anywhere
+from 10 to 40 minutes — the only step that can blow the budget. Start with a ~300-frame clip. A
+recorded 300-frame pass beats a 1000-frame run you killed at the deadline, and the summary records
+the difference honestly.
+
+---
+
+## Part 4 — Collect, then kill
+
+```bash
+rsync -av <instance>:~/gate-results/ ./gate-results/
+```
+
+`gate-results/` holds `gate.summary` (the `PASS`/`FAIL`/`UNRUN` table), `gate.log`,
+`environment.txt`, per-combination output, `compute-sanitizer.txt`, and `benchmarks.txt`.
+
+The script self-stops on a clean finish and the watchdog fires regardless — but **stopped is not
+deleted**, and storage keeps billing on a stopped instance. When you are done with the gate,
+delete the environment and confirm on the provider console that it is gone.
+
+Then gate step 7, which the script cannot do for you: put the versions from `environment.txt`
+(driver, CUDA, TensorRT, DALI) and the summary into `CHANGELOG.md`, **stating the `UNRUN` items
+plainly as unrun**. An unrun check is reported as unrun, never implied to have passed.
+
+---
+
+## Known rough edges
+
+- The script has **no execution history against real hardware**. Budget a few minutes on the first
+  run for a wrong path.
+- The `GTEST_SKIP()`-without-a-device check is untestable on a GPU box by construction. Verify it on
+  a CPU-only host.
+- `probe_tensorrt` searches `build-*/_deps/TensorRT-*/`, then `TENSORRT_ROOTDIR`, then the system
+  include paths, and reads the version from the `NV_TENSORRT_*` macros. It runs *after* step 1
+  because that configure is what downloads TensorRT; before then there is genuinely nothing to find.

--- a/docs/rented-gpu-runbook.md
+++ b/docs/rented-gpu-runbook.md
@@ -102,7 +102,8 @@ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build -
 ctest --test-dir build --output-on-failure -R UnitTests
 ```
 
-Passing here lets you set `SKIP_DEFAULT_PATH=1` on the rented box.
+Passing here lets you set `SKIP_DEFAULT_PATH=1` on the rented box. That skips only this CPU build; the GPU build's UnitTests still run there, which is where `test_gpu_postprocess`
+actually executes instead of `GTEST_SKIP()`-ing.
 
 ### 4. Install your provider's CLI
 
@@ -175,7 +176,7 @@ VIDEO=~/long.mp4 \
 | `VIDEO` | *(unset)* | ≥ 1000 frames, for `compute-sanitizer` |
 | `CUDA_ARCH` | `89` | `CMAKE_CUDA_ARCHITECTURES` for the rented card |
 | `DEADLINE_HOURS` | `6` | Watchdog fires `brev stop` after this, run finished or not |
-| `SKIP_DEFAULT_PATH` | `0` | `1` skips step 6, which needs no GPU |
+| `SKIP_DEFAULT_PATH` | `0` | `1` skips step 6's default ONNX Runtime build, which needs no GPU. Step 6's UnitTests on the GPU build still run — `test_gpu_postprocess` needs the device |
 | `SELF_STOP` | `1` | `0` leaves the instance up after a clean finish |
 | `WATCHDOG` | `1` | `0` does not arm the watchdog at all. **Set this when running at home** — without a `brev` CLI the watchdog falls back to `sudo shutdown -h`, which halts your own machine |
 | `EXTRA_CMAKE_ARGS` | *(empty)* | Extra `-D` flags for the four TensorRT configures, e.g. `-DTENSORRT_ROOTDIR=<prefix>` on a box that already has TensorRT |

--- a/scripts/run_gate.sh
+++ b/scripts/run_gate.sh
@@ -49,8 +49,10 @@ WATCHDOG="${WATCHDOG:-1}"
 # -DTENSORRT_ROOTDIR=<prefix>, which is read as a CMake variable, not an env var.
 read -r -a EXTRA_CMAKE <<< "${EXTRA_CMAKE_ARGS:-}"
 
-# Step 6 needs no GPU. On a rented box that is paid time for nothing — run it at
-# home first and set this to 1 to keep the metered clock on GPU-only work.
+# Step 6's default ONNX Runtime build needs no GPU. On a rented box that is paid
+# time for nothing — run it at home first and set this to 1 to keep the metered
+# clock on GPU-only work. It skips only that CPU build: step 6's UnitTests on the
+# GPU build still run, since test_gpu_postprocess needs the device.
 SKIP_DEFAULT_PATH="${SKIP_DEFAULT_PATH:-0}"
 
 MODEL="${MODEL:-}"                                   # .onnx or .engine — required for steps 2-5
@@ -226,6 +228,10 @@ step_build() {
         fi
         rm -rf "$REPO/build-guard-$opt"
     done
+
+    # Explicit: main() reads this to decide whether steps 2-5 have a binary to
+    # run. Without it the status is whatever the guard loop's rm left behind.
+    return 0
 }
 
 # --- Step 2/3: the four combinations ------------------------------------------
@@ -261,8 +267,8 @@ step_combinations() {
 # --- Step 4: memory and long-run safety ---------------------------------------
 step_sanitizer() {
     note "=== step 4: compute-sanitizer 1000-frame run ==="
-    if [[ -z "$MODEL" || -z "$VIDEO" || ! -f "$VIDEO" ]]; then
-        unrun "compute-sanitizer long run — needs MODEL and a >=1000 frame VIDEO"
+    if [[ -z "$MODEL" || ! -f "$MODEL" || -z "$VIDEO" || ! -f "$VIDEO" ]]; then
+        unrun "compute-sanitizer long run — needs an existing MODEL and a >=1000 frame VIDEO"
         return
     fi
     if ! command -v compute-sanitizer >/dev/null 2>&1; then
@@ -275,15 +281,31 @@ step_sanitizer() {
     compute-sanitizer --tool memcheck "$REPO/build-gpu/inference_app" \
         "$MODEL" "$VIDEO" "$LABELS" --segmentation --gpu-preprocess --gpu-postprocess \
         > "${RESULTS}/compute-sanitizer.txt" 2>&1
+    local rc=$?
+
+    # Two things have to hold, and the exit status is the half that is easy to
+    # drop: an app that dies in the first second still makes the sanitizer print
+    # "ERROR SUMMARY: 0 errors", so the summary line alone would record a clean
+    # 1000-frame run that never happened.
+    #
+    # The count is anchored for the same reason: 'ERROR SUMMARY: 10 errors'
+    # contains the substring '0 errors'.
+    local clean=1
+    grep -qE 'ERROR SUMMARY: 0 errors' "${RESULTS}/compute-sanitizer.txt" || clean=0
+
     # "no ERROR SUMMARY line" is ambiguous: it means either a clean run that was
     # cut short or a sanitizer that never attached. Reporting the second as FAIL
-    # puts a tooling problem in the same column as a real memory error.
-    if grep -qE '0 errors|ERROR SUMMARY: 0' "${RESULTS}/compute-sanitizer.txt"; then
-        pass "compute-sanitizer: no findings on the long run"
-    elif grep -qE 'Unable to find injection library|terminated before first instrumented API call' \
+    # puts a tooling problem in the same column as a real memory error. Checked
+    # first, because a sanitizer that never attached also exits non-zero.
+    if grep -qE 'Unable to find injection library|terminated before first instrumented API call' \
              "${RESULTS}/compute-sanitizer.txt"; then
         unrun "compute-sanitizer could not instrument the app (toolkit/driver mismatch)
           — see compute-sanitizer.txt; NOT a clean run"
+    elif [[ "$rc" -ne 0 ]]; then
+        fail "compute-sanitizer: the run exited $rc — the 1000-frame run did not
+          complete, so zero findings prove nothing. See compute-sanitizer.txt"
+    elif [[ "$clean" -eq 1 ]]; then
+        pass "compute-sanitizer: no findings on the long run"
     else
         fail "compute-sanitizer: findings present — see compute-sanitizer.txt"
     fi
@@ -310,11 +332,15 @@ step_benchmarks() {
 # --- Step 6: the default path is unchanged ------------------------------------
 step_default_path() {
     note "=== step 6: default ONNX Runtime path ==="
+
+    # SKIP_DEFAULT_PATH moves the *CPU* build off the metered clock. It must not
+    # touch the GPU-build UnitTests below: test_gpu_postprocess needs the rented
+    # device to run rather than GTEST_SKIP(), which is the whole reason this
+    # script is on a GPU box at all.
     if [[ "$SKIP_DEFAULT_PATH" == "1" ]]; then
-        unrun "step 6 skipped on this box — run it locally, it needs no GPU"
-        return
-    fi
-    if cmake -S "$REPO" -B "$REPO/build-default" -G Ninja \
+        unrun "default ONNX Runtime build + UnitTests skipped on this box
+          (SKIP_DEFAULT_PATH=1) — run it locally, it needs no GPU"
+    elif cmake -S "$REPO" -B "$REPO/build-default" -G Ninja \
              -DCMAKE_BUILD_TYPE=Release >> "$LOG" 2>&1 \
        && cmake --build "$REPO/build-default" --parallel >> "$LOG" 2>&1 \
        && ctest --test-dir "$REPO/build-default" --output-on-failure -R UnitTests \
@@ -323,6 +349,13 @@ step_default_path() {
     else
         fail "default ONNX Runtime build or UnitTests — see unit-tests-default.txt"
     fi
+
+    # A green build and green UnitTests are not the skill's first step-6 box:
+    # that one asks for output bit-identical to the pre-change baseline, which
+    # needs an inference run and something to diff it against. Neither exists
+    # here, so it is reported unrun rather than absorbed into the PASS above.
+    unrun "default path bit-identical to the pre-change baseline — no baseline
+          artefact and no output-path flag in src/main.cpp; roadmap Phase 1"
 
     if ctest --test-dir "$REPO/build-gpu" --output-on-failure -R UnitTests \
            > "${RESULTS}/unit-tests-gpu.txt" 2>&1; then

--- a/scripts/run_gate.sh
+++ b/scripts/run_gate.sh
@@ -39,6 +39,15 @@ CUDA_ARCH="${CUDA_ARCH:-89}"
 # Hard stop regardless of whether the gate finished. Re-armed on every run.
 DEADLINE_HOURS="${DEADLINE_HOURS:-6}"
 SELF_STOP="${SELF_STOP:-1}"
+# 0 disables the deadline watchdog entirely. The watchdog exists to stop a
+# metered instance; on a local machine its fallback (`sudo shutdown -h`) would
+# halt your own box, so set this to 0 when running the gate at home.
+WATCHDOG="${WATCHDOG:-1}"
+
+# Extra -D flags appended to every TensorRT configure. A box that already has
+# TensorRT (rather than letting cmake/deps download the pinned tarball) needs
+# -DTENSORRT_ROOTDIR=<prefix>, which is read as a CMake variable, not an env var.
+read -r -a EXTRA_CMAKE <<< "${EXTRA_CMAKE_ARGS:-}"
 
 # Step 6 needs no GPU. On a rented box that is paid time for nothing — run it at
 # home first and set this to 1 to keep the metered clock on GPU-only work.
@@ -48,6 +57,18 @@ MODEL="${MODEL:-}"                                   # .onnx or .engine — requ
 VIDEO="${VIDEO:-}"                                   # >= 1000 frames — required for step 4
 IMAGE="${IMAGE:-$REPO/data/dog.jpg}"
 LABELS="${LABELS:-$REPO/data/coco-labels-91.txt}"
+
+# libnvinfer dlopens libnvinfer_builder_resource.so at engine-build time. A
+# dlopen from inside a dependency does not use the executable's RUNPATH, so
+# without this every run dies with "Unable to load library" before it builds
+# an engine. Covers both TensorRT sources: an existing prefix and the tarball
+# cmake/deps downloads into build-gpu/_deps.
+# A prefix may arrive either as TENSORRT_ROOTDIR or inside EXTRA_CMAKE_ARGS.
+TRT_PREFIX="${TENSORRT_ROOTDIR:-$(sed -n 's/.*-DTENSORRT_ROOTDIR=\([^ ]*\).*/\1/p' <<< "${EXTRA_CMAKE_ARGS:-}")}"
+for _trtlib in "${TRT_PREFIX:-/nonexistent}/lib" "$REPO"/build-gpu/_deps/TensorRT-*/lib; do
+    [[ -d "$_trtlib" ]] && LD_LIBRARY_PATH="${_trtlib}:${LD_LIBRARY_PATH:-}"
+done
+export LD_LIBRARY_PATH
 
 mkdir -p "$RESULTS"
 : > "$SUMMARY"
@@ -63,6 +84,10 @@ unrun()  { record UNRUN "$1"; }
 # survives you forgetting about the box; the self-stop at the end only covers
 # the clean path.
 arm_watchdog() {
+    if [[ "$WATCHDOG" != "1" ]]; then
+        note "watchdog disabled (WATCHDOG=0) — nothing will stop this machine"
+        return
+    fi
     if command -v brev >/dev/null 2>&1; then
         sudo systemd-run --on-active="${DEADLINE_HOURS}h" --unit=gate-watchdog \
             "$(command -v brev)" stop "$(hostname)" 2>/dev/null \
@@ -93,7 +118,7 @@ probe_tensorrt() {
     for candidate in \
         "$REPO"/build-gpu/_deps/TensorRT-*/include/NvInferVersion.h \
         "$REPO"/build-*/_deps/TensorRT-*/include/NvInferVersion.h \
-        "${TENSORRT_ROOTDIR:-/nonexistent}"/include/NvInferVersion.h \
+        "${TRT_PREFIX:-/nonexistent}"/include/NvInferVersion.h \
         /usr/include/x86_64-linux-gnu/NvInferVersion.h \
         /usr/include/NvInferVersion.h
     do
@@ -105,11 +130,22 @@ probe_tensorrt() {
         return
     fi
 
+    # TensorRT 10.x does not put the numbers on NV_TENSORRT_*: those expand to
+    # TRT_<part>_ENTERPRISE, which is where the literal lives. Reading $3 blindly
+    # yields "TRT_MAJOR_ENTERPRISE" and writes that into environment.txt, which
+    # step 7 copies into the CHANGELOG. Resolve one level of indirection.
+    trt_define() { # macro name
+        local v
+        v=$(awk -v m="$1" '$1=="#define" && $2==m {print $3; exit}' "$header")
+        [[ "$v" =~ ^[0-9]+$ ]] || v=$(awk -v m="$v" '$1=="#define" && $2==m {print $3; exit}' "$header")
+        echo "$v"
+    }
+
     local major minor patch build
-    major=$(awk '/define NV_TENSORRT_MAJOR/ {print $3}' "$header")
-    minor=$(awk '/define NV_TENSORRT_MINOR/ {print $3}' "$header")
-    patch=$(awk '/define NV_TENSORRT_PATCH/ {print $3}' "$header")
-    build=$(awk '/define NV_TENSORRT_BUILD/ {print $3}' "$header")
+    major=$(trt_define NV_TENSORRT_MAJOR)
+    minor=$(trt_define NV_TENSORRT_MINOR)
+    patch=$(trt_define NV_TENSORRT_PATCH)
+    build=$(trt_define NV_TENSORRT_BUILD)
     echo "TensorRT ${major}.${minor}.${patch}.${build}"
     echo "header: ${header}"
 }
@@ -149,7 +185,7 @@ step_build() {
     if cmake -S "$REPO" -B "$REPO/build-gpu" -G Ninja \
              -DUSE_ONNX_RUNTIME=OFF -DUSE_TENSORRT=ON -DUSE_GPU_PIPELINE=ON \
              -DDALI_ROOT="$DALI_ROOT" -DCMAKE_CUDA_ARCHITECTURES="$CUDA_ARCH" \
-             -DCMAKE_BUILD_TYPE=Release -DWERROR=ON >> "$LOG" 2>&1 \
+             -DCMAKE_BUILD_TYPE=Release -DWERROR=ON "${EXTRA_CMAKE[@]}" >> "$LOG" 2>&1 \
        && cmake --build "$REPO/build-gpu" --parallel >> "$LOG" 2>&1; then
         pass "full TensorRT + DALI + CUDA build"
     else
@@ -162,7 +198,7 @@ step_build() {
     # needs no DALI. A change that silently couples them is a regression.
     if cmake -S "$REPO" -B "$REPO/build-dali-only" -G Ninja \
              -DUSE_ONNX_RUNTIME=OFF -DUSE_TENSORRT=ON -DUSE_DALI=ON \
-             -DDALI_ROOT="$DALI_ROOT" -DCMAKE_BUILD_TYPE=Release >> "$LOG" 2>&1 \
+             -DDALI_ROOT="$DALI_ROOT" -DCMAKE_BUILD_TYPE=Release "${EXTRA_CMAKE[@]}" >> "$LOG" 2>&1 \
        && cmake --build "$REPO/build-dali-only" --parallel >> "$LOG" 2>&1; then
         pass "USE_DALI=ON alone"
     else
@@ -172,7 +208,7 @@ step_build() {
     if cmake -S "$REPO" -B "$REPO/build-cudapost-only" -G Ninja \
              -DUSE_ONNX_RUNTIME=OFF -DUSE_TENSORRT=ON -DUSE_CUDA_POSTPROCESS=ON \
              -DCMAKE_CUDA_ARCHITECTURES="$CUDA_ARCH" \
-             -DCMAKE_BUILD_TYPE=Release >> "$LOG" 2>&1 \
+             -DCMAKE_BUILD_TYPE=Release "${EXTRA_CMAKE[@]}" >> "$LOG" 2>&1 \
        && cmake --build "$REPO/build-cudapost-only" --parallel >> "$LOG" 2>&1; then
         pass "USE_CUDA_POSTPROCESS=ON alone"
     else
@@ -239,8 +275,15 @@ step_sanitizer() {
     compute-sanitizer --tool memcheck "$REPO/build-gpu/inference_app" \
         "$MODEL" "$VIDEO" "$LABELS" --segmentation --gpu-preprocess --gpu-postprocess \
         > "${RESULTS}/compute-sanitizer.txt" 2>&1
+    # "no ERROR SUMMARY line" is ambiguous: it means either a clean run that was
+    # cut short or a sanitizer that never attached. Reporting the second as FAIL
+    # puts a tooling problem in the same column as a real memory error.
     if grep -qE '0 errors|ERROR SUMMARY: 0' "${RESULTS}/compute-sanitizer.txt"; then
         pass "compute-sanitizer: no findings on the long run"
+    elif grep -qE 'Unable to find injection library|terminated before first instrumented API call' \
+             "${RESULTS}/compute-sanitizer.txt"; then
+        unrun "compute-sanitizer could not instrument the app (toolkit/driver mismatch)
+          — see compute-sanitizer.txt; NOT a clean run"
     else
         fail "compute-sanitizer: findings present — see compute-sanitizer.txt"
     fi
@@ -252,7 +295,7 @@ step_benchmarks() {
     if cmake -S "$REPO" -B "$REPO/build-gpu-bench" -G Ninja \
              -DUSE_ONNX_RUNTIME=OFF -DUSE_TENSORRT=ON -DUSE_GPU_PIPELINE=ON \
              -DDALI_ROOT="$DALI_ROOT" -DCMAKE_CUDA_ARCHITECTURES="$CUDA_ARCH" \
-             -DCMAKE_BUILD_TYPE=Release -DBENCHMARKS=ON >> "$LOG" 2>&1 \
+             -DCMAKE_BUILD_TYPE=Release -DBENCHMARKS=ON "${EXTRA_CMAKE[@]}" >> "$LOG" 2>&1 \
        && cmake --build "$REPO/build-gpu-bench" --parallel >> "$LOG" 2>&1 \
        && "$REPO/build-gpu-bench/benchmarks" > "${RESULTS}/benchmarks.txt" 2>&1; then
         pass "benchmarks ran — see benchmarks.txt"

--- a/scripts/run_gate.sh
+++ b/scripts/run_gate.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# run_gate.sh — unattended driver for the gpu-verify checklist on a rented GPU box.
+#
+# Runs every part of .claude/skills/gpu-verify/SKILL.md that is executable today,
+# records the parts that are not, arms a deadline watchdog so a hang cannot bill
+# forever, and stops the instance when it is done.
+#
+#   ./scripts/run_gate.sh                                   # defaults below
+#   MODEL=~/rfdetr.onnx VIDEO=~/long.mp4 ./scripts/run_gate.sh
+#   DEADLINE_HOURS=1 CUDA_ARCH=89 SKIP_DEFAULT_PATH=1 ./scripts/run_gate.sh
+#
+# Run it under tmux so a dropped SSH session does not kill it — a rented box
+# keeps billing whether or not your laptop is open:
+#   tmux new -s gate './scripts/run_gate.sh; bash'
+#
+# Pull results to your own machine at any time (run this locally, not here):
+#   rsync -av <instance>:~/gate-results/ ./gate-results/
+#
+# What it cannot do: the parity tolerances in the skill (preprocessed tensor
+# 2e-2, scores 1e-3, box centres 1 px, mask IoU 0.999) have no fixtures to run
+# against — tests/data/gpu_parity/ is roadmap Phase 2 and does not exist, and
+# src/main.cpp has no output-path flag (Phase 1). Those checks are reported
+# UNRUN. Per the skill: an unrun check is reported as unrun, never implied to
+# have passed.
+#
+# Deliberately NOT `set -e`: a failing check is data, not a reason to abandon the
+# remaining checks. Failures are recorded and the script continues.
+set -uo pipefail
+
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+DALI_ROOT="${DALI_ROOT:-$HOME/dependencies/dali}"
+RESULTS="${RESULTS:-$HOME/gate-results}"
+LOG="${RESULTS}/gate.log"
+SUMMARY="${RESULTS}/gate.summary"
+
+# L4/L40S/RTX-Ada are 89, A4000/A10G/A10/A5000 are 86, A100 is 80, T4 is 75.
+CUDA_ARCH="${CUDA_ARCH:-89}"
+
+# Hard stop regardless of whether the gate finished. Re-armed on every run.
+DEADLINE_HOURS="${DEADLINE_HOURS:-6}"
+SELF_STOP="${SELF_STOP:-1}"
+
+# Step 6 needs no GPU. On a rented box that is paid time for nothing — run it at
+# home first and set this to 1 to keep the metered clock on GPU-only work.
+SKIP_DEFAULT_PATH="${SKIP_DEFAULT_PATH:-0}"
+
+MODEL="${MODEL:-}"                                   # .onnx or .engine — required for steps 2-5
+VIDEO="${VIDEO:-}"                                   # >= 1000 frames — required for step 4
+IMAGE="${IMAGE:-$REPO/data/dog.jpg}"
+LABELS="${LABELS:-$REPO/data/coco-labels-91.txt}"
+
+mkdir -p "$RESULTS"
+: > "$SUMMARY"
+
+note()   { echo "[$(date -Is)] $*" | tee -a "$LOG"; }
+record() { printf '%-8s  %s\n' "$1" "$2" >> "$SUMMARY"; note "$1: $2"; }
+pass()   { record PASS  "$1"; }
+fail()   { record FAIL  "$1"; }
+unrun()  { record UNRUN "$1"; }
+
+# --- Watchdog -----------------------------------------------------------------
+# Fires whether the gate finished, crashed, or hung. This is the layer that
+# survives you forgetting about the box; the self-stop at the end only covers
+# the clean path.
+arm_watchdog() {
+    if command -v brev >/dev/null 2>&1; then
+        sudo systemd-run --on-active="${DEADLINE_HOURS}h" --unit=gate-watchdog \
+            "$(command -v brev)" stop "$(hostname)" 2>/dev/null \
+            && note "watchdog armed: brev stop in ${DEADLINE_HOURS}h" && return
+    fi
+    # Fallback: halt the guest. Verify once on the Brev console that a halted VM
+    # registers as *stopped* (storage-only billing) and not billed-but-off.
+    if sudo shutdown -h "+$((DEADLINE_HOURS * 60))" 2>/dev/null; then
+        note "watchdog armed: shutdown in ${DEADLINE_HOURS}h (verify it bills as stopped)"
+    else
+        note "WARNING: could not arm a watchdog — stop this instance yourself"
+    fi
+}
+
+# --- Environment --------------------------------------------------------------
+capture_env() {
+    note "=== environment ==="
+    {
+        nvidia-smi 2>&1 | head -12
+        echo "--- nvcc ---";     nvcc --version 2>&1 | tail -2
+        echo "--- TensorRT ---"; grep -rhoE 'TensorRT [0-9.]+|NV_TENSORRT_[A-Z]+ +[0-9]+' \
+                                    /usr/include/x86_64-linux-gnu/NvInferVersion.h 2>/dev/null | head
+        echo "--- DALI ---";     find "$DALI_ROOT" -maxdepth 1 2>&1 | head
+        echo "--- repo ---";     git -C "$REPO" log --oneline -1 2>&1
+    } > "${RESULTS}/environment.txt" 2>&1
+    note "environment written to environment.txt (needed for the CHANGELOG entry, step 7)"
+}
+
+# --- Step 1: build the matrix -------------------------------------------------
+step_build() {
+    note "=== step 1: build matrix ==="
+
+    if cmake -S "$REPO" -B "$REPO/build-gpu" -G Ninja \
+             -DUSE_ONNX_RUNTIME=OFF -DUSE_TENSORRT=ON -DUSE_GPU_PIPELINE=ON \
+             -DDALI_ROOT="$DALI_ROOT" -DCMAKE_CUDA_ARCHITECTURES="$CUDA_ARCH" \
+             -DCMAKE_BUILD_TYPE=Release -DWERROR=ON >> "$LOG" 2>&1 \
+       && cmake --build "$REPO/build-gpu" --parallel >> "$LOG" 2>&1; then
+        pass "full TensorRT + DALI + CUDA build"
+    else
+        # Everything downstream needs this binary, so this is the one fatal step.
+        fail "full TensorRT + DALI + CUDA build"
+        return 1
+    fi
+
+    # The halves must build independently — DALI needs no nvcc, CUDA postprocess
+    # needs no DALI. A change that silently couples them is a regression.
+    if cmake -S "$REPO" -B "$REPO/build-dali-only" -G Ninja \
+             -DUSE_ONNX_RUNTIME=OFF -DUSE_TENSORRT=ON -DUSE_DALI=ON \
+             -DDALI_ROOT="$DALI_ROOT" -DCMAKE_BUILD_TYPE=Release >> "$LOG" 2>&1 \
+       && cmake --build "$REPO/build-dali-only" --parallel >> "$LOG" 2>&1; then
+        pass "USE_DALI=ON alone"
+    else
+        fail "USE_DALI=ON alone"
+    fi
+
+    if cmake -S "$REPO" -B "$REPO/build-cudapost-only" -G Ninja \
+             -DUSE_ONNX_RUNTIME=OFF -DUSE_TENSORRT=ON -DUSE_CUDA_POSTPROCESS=ON \
+             -DCMAKE_CUDA_ARCHITECTURES="$CUDA_ARCH" \
+             -DCMAKE_BUILD_TYPE=Release >> "$LOG" 2>&1 \
+       && cmake --build "$REPO/build-cudapost-only" --parallel >> "$LOG" 2>&1; then
+        pass "USE_CUDA_POSTPROCESS=ON alone"
+    else
+        fail "USE_CUDA_POSTPROCESS=ON alone"
+    fi
+
+    # Guard check: these MUST fail at configure time. An architectural
+    # commitment, so a successful configure here is the failure.
+    for opt in USE_DALI USE_CUDA_POSTPROCESS; do
+        if cmake -S "$REPO" -B "$REPO/build-guard-$opt" -G Ninja \
+                 -DUSE_ONNX_RUNTIME=ON "-D${opt}=ON" >> "$LOG" 2>&1; then
+            fail "guard: ${opt} + ONNX Runtime should FATAL_ERROR but configured cleanly"
+        else
+            pass "guard: ${opt} + ONNX Runtime rejected at configure time"
+        fi
+        rm -rf "$REPO/build-guard-$opt"
+    done
+}
+
+# --- Step 2/3: the four combinations ------------------------------------------
+step_combinations() {
+    note "=== step 2/3: four combinations ==="
+    local app="$REPO/build-gpu/inference_app"
+
+    if [[ -z "$MODEL" || ! -f "$MODEL" ]]; then
+        unrun "four combinations — no MODEL set (export .onnx and re-run)"
+        return
+    fi
+
+    # Smoke only. Real parity needs golden fixtures and an output-path flag,
+    # neither of which exists yet (roadmap Phases 1 and 2).
+    run_combo() { # name, extra flags...
+        local name="$1"; shift
+        if "$app" "$MODEL" "$IMAGE" "$LABELS" "$@" > "${RESULTS}/combo-${name}.txt" 2>&1; then
+            pass "combination ${name} ran (smoke only, NOT a parity check)"
+        else
+            fail "combination ${name} crashed — see combo-${name}.txt"
+        fi
+    }
+    run_combo cpu-cpu
+    run_combo gpupre-cpupost --gpu-preprocess
+    run_combo cpupre-gpupost --gpu-postprocess --segmentation
+    run_combo gpu-gpu        --gpu-preprocess --gpu-postprocess --segmentation
+
+    unrun "tolerance checks (tensor 2e-2, scores 1e-3, centres 1px, mask IoU 0.999)
+          — tests/data/gpu_parity/ does not exist; roadmap Phase 2"
+    unrun "dense fixture >100 detections — not built; roadmap Phase 2"
+}
+
+# --- Step 4: memory and long-run safety ---------------------------------------
+step_sanitizer() {
+    note "=== step 4: compute-sanitizer 1000-frame run ==="
+    if [[ -z "$MODEL" || -z "$VIDEO" || ! -f "$VIDEO" ]]; then
+        unrun "compute-sanitizer long run — needs MODEL and a >=1000 frame VIDEO"
+        return
+    fi
+    if ! command -v compute-sanitizer >/dev/null 2>&1; then
+        unrun "compute-sanitizer long run — binary not on PATH (install CUDA toolkit)"
+        return
+    fi
+    # Watch daliOutputRelease ordering here: releasing before the TensorRT
+    # enqueue produces intermittent garbage, not a crash, so a short clean run
+    # proves nothing. This is the check that catches it.
+    compute-sanitizer --tool memcheck "$REPO/build-gpu/inference_app" \
+        "$MODEL" "$VIDEO" "$LABELS" --segmentation --gpu-preprocess --gpu-postprocess \
+        > "${RESULTS}/compute-sanitizer.txt" 2>&1
+    if grep -qE '0 errors|ERROR SUMMARY: 0' "${RESULTS}/compute-sanitizer.txt"; then
+        pass "compute-sanitizer: no findings on the long run"
+    else
+        fail "compute-sanitizer: findings present — see compute-sanitizer.txt"
+    fi
+}
+
+# --- Step 5: benchmarks -------------------------------------------------------
+step_benchmarks() {
+    note "=== step 5: benchmarks ==="
+    if cmake -S "$REPO" -B "$REPO/build-gpu-bench" -G Ninja \
+             -DUSE_ONNX_RUNTIME=OFF -DUSE_TENSORRT=ON -DUSE_GPU_PIPELINE=ON \
+             -DDALI_ROOT="$DALI_ROOT" -DCMAKE_CUDA_ARCHITECTURES="$CUDA_ARCH" \
+             -DCMAKE_BUILD_TYPE=Release -DBENCHMARKS=ON >> "$LOG" 2>&1 \
+       && cmake --build "$REPO/build-gpu-bench" --parallel >> "$LOG" 2>&1 \
+       && "$REPO/build-gpu-bench/benchmarks" > "${RESULTS}/benchmarks.txt" 2>&1; then
+        pass "benchmarks ran — see benchmarks.txt"
+    else
+        fail "benchmarks build or run failed"
+    fi
+
+    unrun "per-stage four-combination benchmark — bench_gpu_pipeline.cpp does not
+          exist; bench_preprocessing.cpp covers only sigmoid/cxcywh/normalize. Phase 2"
+}
+
+# --- Step 6: the default path is unchanged ------------------------------------
+step_default_path() {
+    note "=== step 6: default ONNX Runtime path ==="
+    if [[ "$SKIP_DEFAULT_PATH" == "1" ]]; then
+        unrun "step 6 skipped on this box — run it locally, it needs no GPU"
+        return
+    fi
+    if cmake -S "$REPO" -B "$REPO/build-default" -G Ninja \
+             -DCMAKE_BUILD_TYPE=Release >> "$LOG" 2>&1 \
+       && cmake --build "$REPO/build-default" --parallel >> "$LOG" 2>&1 \
+       && ctest --test-dir "$REPO/build-default" --output-on-failure -R UnitTests \
+            > "${RESULTS}/unit-tests-default.txt" 2>&1; then
+        pass "default ONNX Runtime build + UnitTests"
+    else
+        fail "default ONNX Runtime build or UnitTests — see unit-tests-default.txt"
+    fi
+
+    if ctest --test-dir "$REPO/build-gpu" --output-on-failure -R UnitTests \
+           > "${RESULTS}/unit-tests-gpu.txt" 2>&1; then
+        pass "UnitTests on the GPU build (test_gpu_postprocess runs, not skipped)"
+    else
+        fail "UnitTests on the GPU build — see unit-tests-gpu.txt"
+    fi
+
+    # Cannot be checked here by construction: this box has a device, so the
+    # GTEST_SKIP() path never executes. Run it on a CPU-only machine.
+    unrun "GPU tests report SKIPPED on a device-less machine — untestable on this
+          box by construction; verify on a CPU-only host"
+}
+
+# --- Main ---------------------------------------------------------------------
+main() {
+    note "gate starting; results in ${RESULTS}"
+    arm_watchdog
+    capture_env
+
+    step_build && {
+        step_combinations
+        step_sanitizer
+        step_benchmarks
+    }
+    step_default_path
+
+    note "=== summary ==="
+    sort -k1,1 "$SUMMARY" | tee -a "$LOG"
+    note "$(grep -c '^PASS'  "$SUMMARY") passed, \
+$(grep -c '^FAIL'  "$SUMMARY") failed, \
+$(grep -c '^UNRUN' "$SUMMARY") unrun"
+    note "step 7 is yours: put these numbers, plus environment.txt, in CHANGELOG.md
+          and state the UNRUN items plainly as unrun"
+
+    sync
+    if [[ "$SELF_STOP" == "1" ]] && command -v brev >/dev/null 2>&1; then
+        note "stopping instance — storage-only billing from here"
+        brev stop "$(hostname)"
+    else
+        note "SELF_STOP off or brev CLI missing — STOP THE INSTANCE YOURSELF"
+    fi
+}
+
+main "$@"

--- a/scripts/run_gate.sh
+++ b/scripts/run_gate.sh
@@ -78,15 +78,66 @@ arm_watchdog() {
 }
 
 # --- Environment --------------------------------------------------------------
+# Step 7 of the skill wants driver, CUDA, TensorRT and DALI versions in the
+# CHANGELOG, so these probes have to actually find something.
+
+# TensorRT is normally NOT a system package here: cmake/deps/packages/TensorRT.cmake
+# downloads the tarball and extracts it under ${CMAKE_BINARY_DIR}/_deps, so a probe
+# that only looks in /usr/include finds nothing on a correct build. Search the build
+# trees first, then TENSORRT_ROOTDIR, then the system paths, and read the version
+# from the macros rather than guessing it from the directory name — a pin can be
+# edited without the extracted path following.
+probe_tensorrt() {
+    local header=""
+    local candidate
+    for candidate in \
+        "$REPO"/build-gpu/_deps/TensorRT-*/include/NvInferVersion.h \
+        "$REPO"/build-*/_deps/TensorRT-*/include/NvInferVersion.h \
+        "${TENSORRT_ROOTDIR:-/nonexistent}"/include/NvInferVersion.h \
+        /usr/include/x86_64-linux-gnu/NvInferVersion.h \
+        /usr/include/NvInferVersion.h
+    do
+        [[ -f "$candidate" ]] && { header="$candidate"; break; }
+    done
+
+    if [[ -z "$header" ]]; then
+        echo "NvInferVersion.h not found — run this after step 1, which downloads TensorRT"
+        return
+    fi
+
+    local major minor patch build
+    major=$(awk '/define NV_TENSORRT_MAJOR/ {print $3}' "$header")
+    minor=$(awk '/define NV_TENSORRT_MINOR/ {print $3}' "$header")
+    patch=$(awk '/define NV_TENSORRT_PATCH/ {print $3}' "$header")
+    build=$(awk '/define NV_TENSORRT_BUILD/ {print $3}' "$header")
+    echo "TensorRT ${major}.${minor}.${patch}.${build}"
+    echo "header: ${header}"
+}
+
+# DALI ships no version header in the extracted wheel, so the honest identifier is
+# the Triton image it was extracted from — that is what fetch_dali.sh pins.
+probe_dali() {
+    if [[ ! -f "${DALI_ROOT}/include/dali/c_api.h" ]]; then
+        echo "DALI not staged at ${DALI_ROOT} — run scripts/fetch_dali.sh"
+        return
+    fi
+    echo "staged at ${DALI_ROOT}"
+    # Reads the pin out of fetch_dali.sh's own `${TRITON_IMAGE:-<default>}`, so the
+    # recorded provenance follows the pin instead of duplicating it here.
+    echo "extracted from: ${TRITON_IMAGE:-$(sed -n 's/.*TRITON_IMAGE:-\([^}]*\)}.*/\1/p' \
+        "$REPO/scripts/fetch_dali.sh" 2>/dev/null)}"
+    find "$DALI_ROOT" -maxdepth 1 -name 'libdali*.so' -printf '%f %s bytes\n' 2>/dev/null
+}
+
 capture_env() {
     note "=== environment ==="
     {
-        nvidia-smi 2>&1 | head -12
-        echo "--- nvcc ---";     nvcc --version 2>&1 | tail -2
-        echo "--- TensorRT ---"; grep -rhoE 'TensorRT [0-9.]+|NV_TENSORRT_[A-Z]+ +[0-9]+' \
-                                    /usr/include/x86_64-linux-gnu/NvInferVersion.h 2>/dev/null | head
-        echo "--- DALI ---";     find "$DALI_ROOT" -maxdepth 1 2>&1 | head
-        echo "--- repo ---";     git -C "$REPO" log --oneline -1 2>&1
+        echo "--- driver / GPU ---"; nvidia-smi 2>&1 | head -12
+        echo "--- nvcc ---";         nvcc --version 2>&1 | tail -2
+        echo "--- TensorRT ---";     probe_tensorrt
+        echo "--- DALI ---";         probe_dali
+        echo "--- repo ---";         git -C "$REPO" log --oneline -1 2>&1
+        echo "--- arch ---";         echo "CMAKE_CUDA_ARCHITECTURES=${CUDA_ARCH}"
     } > "${RESULTS}/environment.txt" 2>&1
     note "environment written to environment.txt (needed for the CHANGELOG entry, step 7)"
 }
@@ -247,13 +298,24 @@ step_default_path() {
 main() {
     note "gate starting; results in ${RESULTS}"
     arm_watchdog
+
+    # Cheap preflight so a missing toolchain shows up in seconds rather than
+    # after a long failing configure.
+    command -v nvidia-smi >/dev/null || note "WARNING: no nvidia-smi — is this a GPU box?"
+    command -v nvcc       >/dev/null || note "WARNING: no nvcc — CUDA postprocess will not build"
+
+    local build_ok=0
+    step_build || build_ok=1
+
+    # After step 1, not before: TensorRT is downloaded by that configure into
+    # build-gpu/_deps, so probing earlier would report it missing on every box.
     capture_env
 
-    step_build && {
+    if [[ "$build_ok" -eq 0 ]]; then
         step_combinations
         step_sanitizer
         step_benchmarks
-    }
+    fi
     step_default_path
 
     note "=== summary ==="

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -18,6 +18,11 @@ Before starting any phase, run the [`feature-spec`](../.claude/skills/feature-sp
 
 From the Known Issues table in [CHANGELOG.md](../CHANGELOG.md). Independent of each other and of everything below.
 
+- [ ] Make `src/backends/tensorrt_backend.cpp` compile under `-DWERROR=ON`
+  - The gpu-verify gate builds with `-DWERROR=ON`, so this fails gate step 1 and skips every later step
+  - Mechanical: `-Wsign-conversion` at 148, 161, 257, 267, 271; `-Wunused-parameter` on `input_shape` at 171
+  - A decision, not mechanical: `kEXPLICIT_BATCH` (180) is a no-op in TensorRT 10, and `platformHasFastFp16()` (223) / `BuilderFlag::kFP16` (224) are superseded by strongly-typed networks
+  - Touches a CI-unexecutable path, so it needs a spec directory per [AGENTS.md](../AGENTS.md)
 - [ ] Support the active-first keypoint schema (`rfdetr` 1.8.2+)
   - Upstream 1.8.2 changed the default `num_keypoints_per_class` from background-first `[0, 17]` to active-first `[17]` ([#1160](https://github.com/roboflow/rf-detr/pull/1160)); `Config::keypoint_counts` still defaults to `{0, 17}` and has no CLI override
   - `deploy/requirements.txt` pins 1.9.4, so the documented export path produces a schema the default build cannot decode — expected to throw `Keypoint tensor channels (17) not divisible by number of keypoint classes (2)`
@@ -42,6 +47,8 @@ From the Known Issues table in [CHANGELOG.md](../CHANGELOG.md). Independent of e
 The parity gate the GPU work was supposed to be measured against was never built. Everything in Phases 3 and 4 depends on it.
 
 Spec: [`features/2026-08-15-gpu-parity-fixtures/`](features/2026-08-15-gpu-parity-fixtures/) — acceptance criteria and tolerances live in its `validation.md`.
+
+**Evidence from the first real gate run (2026-08-26).** The four combinations split by *preprocessing*, not postprocessing: `cpu-cpu` and `cpupre-gpupost` agree to the last digit, as do `gpupre-cpupost` and `gpu-gpu` — CUDA postprocessing is bit-identical to CPU. DALI preprocessing is not: max score delta 0.0163 on one image, 16× the 1e-3 score tolerance. One image and final scores rather than the preprocessed tensor, so not conclusive — but write these fixtures expecting to find a discrepancy, not to confirm its absence. Details in [CHANGELOG.md](../CHANGELOG.md).
 
 - [ ] Add golden CPU fixtures under `tests/data/gpu_parity/` (directory does not exist)
   - A small, a wide, and a tall image; save the CPU-produced preprocessed tensor and the final detections/masks with explicit tolerances


### PR DESCRIPTION
Turns the executable part of the [gpu-verify](.claude/skills/gpu-verify/SKILL.md) checklist into one script that can be started under `tmux` on a rented GPU box and left alone.

The checklist is the only thing standing between the TensorRT, DALI and CUDA paths and an unverified release, and running it means renting a GPU by the hour. Two things made that awkward: it is a document, so every run was hand-driven from an SSH session that dies when the laptop closes, and a hung or finished run keeps billing until someone notices.

## What it runs

| Step | Coverage |
|------|----------|
| 1 | Full TensorRT+DALI+CUDA build, both halves independently, and the two `USE_DALI` / `USE_CUDA_POSTPROCESS` + ONNX Runtime configure guards that must `FATAL_ERROR` |
| 2 | The four pre/post combinations — **smoke runs only**, see below |
| 4 | `compute-sanitizer` memcheck over a long video |
| 5 | Benchmarks |
| 6 | Default ONNX Runtime build + UnitTests |

Results land in `~/gate-results/` as a `PASS`/`FAIL`/`UNRUN` summary plus per-check output — which is what step 7 asks you to paste into the CHANGELOG.

## What it deliberately does not do

`tests/data/gpu_parity/` does not exist and `src/main.cpp` has no output-path flag — roadmap Phases 2 and 1 respectively. So the tolerances the gate is actually built around (preprocessed tensor `max |Δ| ≤ 2e-2`, scores within `1e-3`, box centres within 1 px, mask IoU ≥ 0.999) have nothing to run against.

Those are reported `UNRUN` rather than skipped silently, and the four combinations it *can* run are labelled smoke tests, not parity checks. Per the skill's own rule: an unrun check is reported as unrun, never implied to have passed.

**Running this script is not passing the gate.** Phase 2 still gates Phase 4.

## Cost control

This runs on metered hardware, so:

- A `systemd-run` deadline watchdog fires `brev stop` after `DEADLINE_HOURS` whether the run finished, crashed, or hung — the self-stop at the end only covers the clean path.
- `SKIP_DEFAULT_PATH=1` moves step 6, which needs no GPU, back to a local machine and off the metered clock.
- `CUDA_ARCH` defaults to `89` rather than the CMake default `86`; the arch is a property of the rented box, not of this project.

Not `set -e`: a failing check is data, not a reason to abandon the remaining checks.

## Two things untestable from the script by construction

Both say so in their `UNRUN` line rather than being omitted:

- The `GTEST_SKIP()`-without-a-device behaviour needs a machine with **no** CUDA device.
- The guest-shutdown watchdog fallback needs one manual confirmation on the provider console that a halted VM bills as *stopped* rather than billed-but-off.

## Scope

No `specs/features/` directory — per `AGENTS.md` a spec is required for a roadmap phase, a release, an rfdetr alignment, or a path CI cannot execute. This adds a helper script and touches no `src/`, so it is CHANGELOG-only. No README change either: it alters no code, build option, backend version, Docker image, or export package.

## Testing

`bash -n` and `shellcheck` clean. **Not yet run against real hardware** — the `nvidia-smi` / `nvcc` / `NvInferVersion.h` probes and the assumption that `brev` is on `PATH` are guesses until a first run on a rented box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ah2iVCK9ohyNMZwdbqynCU