### PR TITLE
fix: compile the TensorRT and GPU paths in CI, and fix what that caught

### DIFF
--- a/.github/workflows/gpu-compile.yml
+++ b/.github/workflows/gpu-compile.yml
@@ -1,0 +1,73 @@
+# Compile gate for the paths CI cannot execute.
+#
+# GitHub runners have no GPU, so TensorRT, DALI and the CUDA kernels can never be
+# *run* here — but they can be *compiled*, and until this workflow existed they
+# were not: src/backends/tensorrt_backend.cpp and src/gpu/ were built for the
+# first time on a rented GPU box, where a -Werror wall of sign-conversion and
+# TensorRT 10 deprecation errors burned gate time that was paid for by the hour.
+#
+# The job stages headers-only TensorRT and DALI prefixes (see
+# scripts/ci/stage_gpu_headers.sh) and builds the static library target with
+# -DWERROR=ON. It does not link and does not run: manual verification of the GPU
+# path is still the gate, per .claude/skills/gpu-verify/SKILL.md.
+name: GPU Backend Compile
+
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    branches: [master, develop]
+
+jobs:
+  compile:
+    # Pinned: scripts/ci/stage_gpu_headers.sh pulls from the ubuntu2404 CUDA repo.
+    runs-on: ubuntu-24.04
+    name: ${{ matrix.name }} (compile, -DWERROR=ON)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The two GPU halves are independent options, so each combination is a
+          # distinct set of #if branches. Build all four.
+          - name: TensorRT
+            options: -DUSE_DALI=OFF -DUSE_CUDA_POSTPROCESS=OFF
+          - name: TensorRT + DALI
+            options: -DUSE_DALI=ON -DUSE_CUDA_POSTPROCESS=OFF
+          - name: TensorRT + CUDA postprocess
+            options: -DUSE_DALI=OFF -DUSE_CUDA_POSTPROCESS=ON
+          - name: TensorRT + full GPU pipeline
+            options: -DUSE_GPU_PIPELINE=ON
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-deps
+
+      - name: Restore staged GPU headers
+        uses: actions/cache@v4
+        with:
+          path: ~/dependencies
+          key: gpu-headers-${{ hashFiles('scripts/ci/stage_gpu_headers.sh') }}
+
+      - name: Stage TensorRT and DALI headers
+        run: ./scripts/ci/stage_gpu_headers.sh
+
+      - name: Install nvcc and the CUDA runtime headers
+        run: |
+          curl -fsSLO https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cuda-nvcc-13-0 cuda-cudart-dev-13-0
+          echo "/usr/local/cuda-13.0/bin" >> "$GITHUB_PATH"
+
+      - name: Configure
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DUSE_ONNX_RUNTIME=OFF -DUSE_TENSORRT=ON ${{ matrix.options }} \
+            -DTENSORRT_ROOTDIR="$HOME/dependencies/tensorrt-headers" \
+            -DDALI_ROOT="$HOME/dependencies/dali-headers" \
+            -DCMAKE_BUILD_TYPE=Release -DWERROR=ON \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Compile
+        # The static library only. The staged TensorRT/DALI shared objects are
+        # stubs with no symbols, so any target that links is out of reach here.
+        run: cmake --build build --parallel --target rfdetr_inference_lib

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ The `executorch` variant builds the ExecuTorch runtime from source into `/opt/ex
 - Either option with the ONNX Runtime backend is a configure-time `FATAL_ERROR`
 - Runtime flags (default off): `--gpu-preprocess`, `--gpu-postprocess` (segmentation only), `--dali-pipeline-dir <dir>` (default `data/dali`)
 - Regenerate `.dali` pipelines for a new resolution: `./scripts/generate_dali_pipelines.sh <res>` (needs `--gpus all` Docker); 432 and 576 are checked in
-- GPU unit tests (`test_gpu_postprocess.cpp`) `GTEST_SKIP()` without a CUDA device; like TensorRT, CI compiles but does not execute GPU paths — test manually with [gpu-verify](.claude/skills/gpu-verify/SKILL.md)
+- GPU unit tests (`test_gpu_postprocess.cpp`) `GTEST_SKIP()` without a CUDA device; like TensorRT, CI compiles but does not execute GPU paths — `gpu-compile.yml` builds all four `USE_DALI`/`USE_CUDA_POSTPROCESS` combinations with `-DWERROR=ON` against headers staged by `scripts/ci/stage_gpu_headers.sh`, so a compile break is a red PR, not a surprise on metered hardware. Behaviour still has to be tested manually with [gpu-verify](.claude/skills/gpu-verify/SKILL.md)
 - On a rented GPU box, `./scripts/run_gate.sh` drives the executable part of that checklist unattended and reports the rest as `UNRUN`; it arms a deadline watchdog and stops the instance when done. Env knobs: `CUDA_ARCH` (default `89`), `DEADLINE_HOURS`, `SKIP_DEFAULT_PATH`, `SELF_STOP`, `MODEL`, `VIDEO`. End-to-end procedure — choosing an instance, export prep, setup script, collecting results: [docs/rented-gpu-runbook.md](docs/rented-gpu-runbook.md)
 - Design constraints: [specs/gpu-pipeline.md](specs/gpu-pipeline.md) — remaining phases: [specs/roadmap.md](specs/roadmap.md)
 
@@ -128,4 +128,4 @@ Requires a plain Debug build (no sanitizers — ASan/TSan conflict with Valgrind
 - Only one backend (ONNX Runtime, TensorRT, or ExecuTorch) can be enabled at compile time.
 - TensorRT requires manually installed CUDA toolkit.
 - Data directory is auto-created by CMake.
-- CI does not test the TensorRT or ExecuTorch backends; test those manually.
+- CI compiles the TensorRT backend and the GPU pipeline (`gpu-compile.yml`) but cannot run them; ExecuTorch is neither compiled nor run by CI. Test the behaviour of all three manually.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ upstream `rfdetr` releases it is kept in step with.
 
 ## [Unreleased]
 
+### CI: compile the TensorRT and GPU paths, and fix what that immediately caught
+
+`src/backends/tensorrt_backend.cpp` and `src/gpu/` were never compiled by CI. The first build of
+them happened on a rented GPU box, on the metered clock, and it failed before it ran a single
+kernel: eight `-Werror` errors — `-Wsign-conversion` on the binding-volume and file-size
+arithmetic, `-Wdeprecated-declarations` on three TensorRT 10 APIs, and an unused parameter. None
+of that needs a GPU to catch. It needs headers.
+
+`gpu-compile.yml` stages headers-only TensorRT and DALI prefixes and builds the static library
+target with `-DWERROR=ON` across all four `USE_DALI`/`USE_CUDA_POSTPROCESS` combinations, since the
+two GPU halves are independent options and each combination is a distinct set of `#if` branches. It
+does not link and it does not run — the staged shared objects are empty stubs, present only because
+the dependency resolver checks that the files exist. This is a compile gate, not a verification
+gate: [gpu-verify](.claude/skills/gpu-verify/SKILL.md) still owns behaviour, and Phase 2 still
+gates Phase 4.
+
+#### Fixed
+
+| File | Change |
+|------|--------|
+| `src/backends/tensorrt_backend.cpp` | Binding and output volumes cast to `size_t` explicitly; `serialize_engine`/`deserialize_engine` cast to `std::streamsize`, and `deserialize_engine` now rejects a negative `tellg()` rather than converting it into a huge allocation. |
+| `src/backends/tensorrt_backend.cpp` | `kEXPLICIT_BATCH` is skipped on TensorRT 10, where explicit batch is the only mode and `createNetworkV2` takes no flag. `platformHasFastFp16()` is dropped there too — every GPU TensorRT 10 supports has fast FP16. `BuilderFlag::kFP16` keeps a localized deprecation suppression: it is deprecated in favour of strongly-typed networks, but this build is deliberately weakly typed so that an FP32 ONNX still gets FP16 kernels, and the flag is the only way to ask for that. Migrating would silently cost FP16. |
+| `src/backends/tensorrt_backend.cpp` | `build_engine_from_onnx` marks `input_shape` unused, matching the idiom already used elsewhere in the file. |
+
+#### Added
+
+| File | Change |
+|------|--------|
+| `.github/workflows/gpu-compile.yml` | New. Compile-only matrix — TensorRT alone, +DALI, +CUDA postprocess, +both — with `-DWERROR=ON`. Installs `cuda-nvcc-13-0` and `cuda-cudart-dev-13-0` from NVIDIA's apt repo, and caches the staged headers on the hash of the staging script so a pin change invalidates them. |
+| `scripts/ci/stage_gpu_headers.sh` | New. Assembles the two prefixes from the smallest artifacts carrying the pinned headers: the `libnvinfer-headers-dev` / `libnvonnxparsers-dev` debs (~130 KB, unpacked with `dpkg-deb -x` so the 2 GB `libnvinfer10` runtime is never pulled in), and `include/` out of the DALI wheel — the same tree `scripts/fetch_dali.sh` takes from the Triton container. The real distributions are 6.2 GB and 380 MB. |
+| `AGENTS.md`, `README.md`, `specs/tech-stack.md` | The claim that CI never builds these paths is no longer true. The CI coverage tables and the pin-duplication list record the new workflow and the versions `stage_gpu_headers.sh` has to keep in step with `cmake/deps/packages/TensorRT.cmake` and `scripts/fetch_dali.sh`. |
+
 ### RF-DETR 1.9.3 / 1.9.4 alignment
 
 **Upstream releases**: [1.9.3](https://github.com/roboflow/rf-detr/releases/tag/1.9.3),

--- a/README.md
+++ b/README.md
@@ -885,7 +885,8 @@ scheme with `rfdetr-keypoint` / `rfdetr-keypoint-preview` and `RFDETR_KEYPOINT_M
 
 ### Manual Cross-Backend Checks
 
-CI exercises neither TensorRT nor ExecuTorch, so backend agreement is verified by hand.
+CI compiles the TensorRT backend but has no GPU to run it on, and does not build ExecuTorch at
+all, so backend agreement is verified by hand.
 [docs/backend-parity-segmentation-video.md](docs/backend-parity-segmentation-video.md) records a
 segmentation video run across all three backends — commands, results, and the parity comparison.
 
@@ -911,12 +912,19 @@ cmake --build build --target benchmarks --parallel
 
 ### CI
 
-Two GitHub Actions workflows run on every push/PR to `master` and `develop`:
+Three GitHub Actions workflows run on every push/PR to `master` and `develop`:
 
 | Workflow | File | What it does |
 |----------|------|-------------|
 | **C++ Lint & Build** | `lint.yml` | Format check, clang-tidy, cppcheck, build with `-DWERROR=ON` |
 | **Build & Test** | `ci.yml` | Build with benchmarks, run unit tests, run benchmarks, run unit tests under ASan+UBSan |
+| **GPU Backend Compile** | `gpu-compile.yml` | Compiles the TensorRT backend and both GPU halves with `-DWERROR=ON`, across all four `USE_DALI`/`USE_CUDA_POSTPROCESS` combinations |
+
+`gpu-compile.yml` runs on GPU-less runners, so it compiles but never links or executes. It stages
+headers-only TensorRT and DALI prefixes with `scripts/ci/stage_gpu_headers.sh` — the full TensorRT
+tarball is 6.2 GB and the DALI wheel 380 MB, against ~130 KB of TensorRT header debs and a few MB
+of DALI headers — and builds only the `rfdetr_inference_lib` static target. Runtime behaviour of
+the GPU path is still gated on manual verification, on real hardware.
 
 ---
 

--- a/scripts/ci/stage_gpu_headers.sh
+++ b/scripts/ci/stage_gpu_headers.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Stage headers-only TensorRT and DALI prefixes for the CI compile gate.
+#
+# CI runners have no GPU and the gate never links or runs these libraries — it
+# only has to compile src/backends/tensorrt_backend.cpp and src/gpu/ under
+# -DWERROR=ON, which needs headers alone. The real distributions are far too
+# large for a per-PR job (the TensorRT tarball is 6.2 GB, the DALI wheel 380 MB
+# of which the headers are a few), so each prefix is assembled from the smallest
+# artifact that carries the pinned headers:
+#
+#   TensorRT  <- libnvinfer-headers-dev + libnvonnxparsers-dev from NVIDIA's CUDA
+#                apt repo (~130 KB together), unpacked with `dpkg-deb -x` so the
+#                dependency on the 2 GB libnvinfer10 runtime is never resolved.
+#   DALI      <- include/ out of the pip wheel, which is the same tree
+#                scripts/fetch_dali.sh copies out of the Triton container.
+#
+# The shared libraries are stubs. The dependency resolver checks that the files
+# exist before declaring the package found, and the gate builds only the static
+# rfdetr_inference_lib target, so nothing ever links against them. A build that
+# has to *run* needs the real thing: scripts/fetch_dali.sh and the TensorRT
+# tarball pinned in cmake/deps/packages/TensorRT.cmake.
+#
+#   ./scripts/ci/stage_gpu_headers.sh [dest]   # default dest: ~/dependencies
+#
+# Then configure with -DTENSORRT_ROOTDIR=<dest>/tensorrt-headers
+#                     -DDALI_ROOT=<dest>/dali-headers
+set -euo pipefail
+
+# Must match cmake/deps/packages/TensorRT.cmake (PROVIDED_VERSION + the cuda tag
+# in PROVIDED_URL) and the DALI build inside the Triton image pinned in
+# scripts/fetch_dali.sh. See "Known pin duplications" in specs/tech-stack.md.
+TENSORRT_DEB_VERSION="${TENSORRT_DEB_VERSION:-10.13.3.9-1+cuda13.0}"
+DALI_VERSION="${DALI_VERSION:-1.51.2}"
+
+CUDA_REPO="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64"
+DALI_INDEX="https://pypi.nvidia.com/nvidia-dali-cuda120"
+
+DEST="${1:-${HOME}/dependencies}"
+TRT_DIR="${DEST}/tensorrt-headers"
+DALI_DIR="${DEST}/dali-headers"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT
+
+# A .so that exists and exports nothing. Enough for the dependency resolver's
+# existence check; useless to a linker, which is the point — see the header.
+stub_lib() {
+    local out="$1"
+    mkdir -p "$(dirname "${out}")"
+    echo 'void rfdetr_ci_stub(void) {}' | cc -shared -x c - -o "${out}"
+}
+
+if [[ -f "${TRT_DIR}/include/NvInfer.h" ]]; then
+    echo "TensorRT headers already staged at ${TRT_DIR}"
+else
+    echo "Staging TensorRT ${TENSORRT_DEB_VERSION} headers -> ${TRT_DIR}"
+    for pkg in libnvinfer-headers-dev libnvonnxparsers-dev; do
+        curl -fsSL -o "${tmp}/${pkg}.deb" \
+            "${CUDA_REPO}/${pkg}_${TENSORRT_DEB_VERSION}_amd64.deb"
+        dpkg-deb -x "${tmp}/${pkg}.deb" "${tmp}/trt-root"
+    done
+    mkdir -p "${TRT_DIR}/include"
+    cp -a "${tmp}/trt-root/usr/include/x86_64-linux-gnu/." "${TRT_DIR}/include/"
+    stub_lib "${TRT_DIR}/lib/libnvinfer.so"
+    stub_lib "${TRT_DIR}/lib/libnvonnxparser.so"
+fi
+
+if [[ -f "${DALI_DIR}/include/dali/c_api.h" ]]; then
+    echo "DALI headers already staged at ${DALI_DIR}"
+else
+    echo "Staging DALI ${DALI_VERSION} headers -> ${DALI_DIR}"
+    wheel="nvidia_dali_cuda120-${DALI_VERSION}-py3-none-manylinux2014_x86_64.whl"
+    curl -fsSL -o "${tmp}/${wheel}" "${DALI_INDEX}/${wheel}"
+    unzip -q "${tmp}/${wheel}" 'nvidia/dali/include/*' -d "${tmp}/dali-root"
+    mkdir -p "${DALI_DIR}"
+    cp -a "${tmp}/dali-root/nvidia/dali/include" "${DALI_DIR}/"
+    # PROVIDED_LIBRARIES for DALI are relative to the root, not root/lib —
+    # fetch_dali.sh puts the real ones there too.
+    stub_lib "${DALI_DIR}/libdali.so"
+    stub_lib "${DALI_DIR}/libdali_operators.so"
+fi
+
+for guard in "${TRT_DIR}/include/NvInfer.h" "${TRT_DIR}/include/NvOnnxParser.h" \
+             "${DALI_DIR}/include/dali/c_api.h" "${DALI_DIR}/include/dali/operators.h"; do
+    if [[ ! -f "${guard}" ]]; then
+        echo "error: ${guard} missing after staging" >&2
+        exit 1
+    fi
+done
+
+echo "Staged: TENSORRT_ROOTDIR=${TRT_DIR} DALI_ROOT=${DALI_DIR}"

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -71,7 +71,7 @@ These are enforced at configure time or by the runtime — not style preferences
 - The three sanitizer modes are mutually exclusive. Valgrind needs a plain Debug build — ASan and TSan conflict with it.
 - `USE_DALI` and `USE_CUDA_POSTPROCESS` require the TensorRT backend. Either with ONNX Runtime is a `FATAL_ERROR`.
 - `--gpu-postprocess` additionally requires `--segmentation`.
-- **CI runners are all `ubuntu-latest` with no GPU.** TensorRT, ExecuTorch, DALI, and CUDA paths are never built or run by CI. You **must** verify those manually — see [AGENTS.md](../AGENTS.md).
+- **CI runners have no GPU.** `gpu-compile.yml` *compiles* the TensorRT, DALI and CUDA paths under `-DWERROR=ON` against headers-only prefixes, but nothing links and nothing runs there; ExecuTorch is not built by CI at all. Behaviour — parity, sanitizers, benchmarks — you **must** verify manually: see [AGENTS.md](../AGENTS.md).
 
 ## CI coverage
 
@@ -79,6 +79,7 @@ These are enforced at configure time or by the runtime — not style preferences
 |----------|------|
 | `ci.yml` — Build & Test | Build & Unit Tests (+ benchmarks), Sanitizers (ASan+UBSan), ThreadSanitizer, Valgrind Memcheck |
 | `lint.yml` — C++ Lint & Build | Format Check, Clang-Tidy, Cppcheck, Build with Strict Warnings (`-DWERROR=ON`) |
+| `gpu-compile.yml` — GPU Backend Compile | Compile-only matrix, `-DWERROR=ON`: TensorRT alone, +DALI, +CUDA postprocess, +both. Builds `rfdetr_inference_lib` only — the staged shared objects are stubs, so no target that links is reachable |
 | `deps-modes.yml` — Dependency Modes | `workflow_dispatch` only; matrix over apt / conan / vcpkg |
 
 Both push/PR workflows trigger on `master` and `develop`. Integration tests are not run by CI.
@@ -89,4 +90,5 @@ Update both sides together:
 
 - TensorRT `10.13.3.9` is pinned in `cmake/deps/packages/TensorRT.cmake:9` **and** hardcoded as a path in `Dockerfile:148-150`.
 - The Triton container tag `25.12-py3` appears in `scripts/fetch_dali.sh:16`, `scripts/generate_dali_pipelines.sh:15`, and `export_trt.sh`.
+- `scripts/ci/stage_gpu_headers.sh` pins the same two components a third time, in the form the CI compile gate can fetch: `TENSORRT_DEB_VERSION` must track `cmake/deps/packages/TensorRT.cmake`, and `DALI_VERSION` must track the DALI build inside the Triton tag above.
 - `project()` declares **no version**. `vcpkg.json` says `0.1.0`; the README badge says `0.4.0`. They disagree.

--- a/src/backends/tensorrt_backend.cpp
+++ b/src/backends/tensorrt_backend.cpp
@@ -145,7 +145,7 @@ std::vector<int64_t> TensorRTBackend::initialize(const std::filesystem::path &mo
         // Allocate CUDA device memory for this binding
         size_t binding_size = 1;
         for (int j = 0; j < dims.nbDims; ++j) {
-            binding_size *= dims.d[j];
+            binding_size *= static_cast<size_t>(dims.d[j]);
         }
         binding_size *= sizeof(float); // Assuming float32
 
@@ -157,8 +157,8 @@ std::vector<int64_t> TensorRTBackend::initialize(const std::filesystem::path &mo
     // Allocate host output buffers
     for (const auto &shape : output_shapes_) {
         size_t size = 1;
-        for (auto dim : shape) {
-            size *= dim;
+        for (const auto dim : shape) {
+            size *= static_cast<size_t>(dim);
         }
         host_output_buffers_.emplace_back(size);
     }
@@ -169,6 +169,9 @@ std::vector<int64_t> TensorRTBackend::initialize(const std::filesystem::path &mo
 
 bool TensorRTBackend::build_engine_from_onnx(const std::filesystem::path &model_path,
                                              const std::vector<int64_t> &input_shape) {
+    // The ONNX graph carries its own static input shape; no optimization profile is set here.
+    (void)input_shape;
+
     // Create builder
     auto builder = std::unique_ptr<nvinfer1::IBuilder, TensorRTDeleter>(nvinfer1::createInferBuilder(logger_));
     if (!builder) {
@@ -176,10 +179,17 @@ bool TensorRTBackend::build_engine_from_onnx(const std::filesystem::path &model_
         return false;
     }
 
-    // Create network with explicit batch flag
-    const auto explicit_batch = 1U << static_cast<uint32_t>(nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH);
+// Create network with explicit batch semantics.
+// TensorRT 10 deprecated kEXPLICIT_BATCH: explicit batch is the only supported mode there,
+// so createNetworkV2 takes no flag.
+#if NV_TENSORRT_MAJOR >= 10
+    const uint32_t network_flags = 0U;
+#else
+    const uint32_t network_flags =
+        1U << static_cast<uint32_t>(nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH);
+#endif
     auto network =
-        std::unique_ptr<nvinfer1::INetworkDefinition, TensorRTDeleter>(builder->createNetworkV2(explicit_batch));
+        std::unique_ptr<nvinfer1::INetworkDefinition, TensorRTDeleter>(builder->createNetworkV2(network_flags));
     if (!network) {
         std::cerr << "Failed to create TensorRT network" << std::endl;
         return false;
@@ -219,11 +229,15 @@ bool TensorRTBackend::build_engine_from_onnx(const std::filesystem::path &model_
 
     // Enable FP16 mode if supported
 #if NV_TENSORRT_MAJOR >= 10
-    // TensorRT 10+ deprecated platformHasFastFp16, use hardwareCompatibilityLevel instead
-    if (builder->platformHasFastFp16()) {
-        config->setFlag(nvinfer1::BuilderFlag::kFP16);
-        std::cout << "[TensorRT] FP16 mode enabled" << std::endl;
-    }
+    // TensorRT 10 deprecated platformHasFastFp16() (every GPU it supports has fast FP16) and
+    // BuilderFlag::kFP16 (superseded by strongly-typed networks). We keep the weakly-typed
+    // builder so an FP32 ONNX still gets FP16 kernels, and kFP16 is the only way to ask for
+    // that -- hence the localized suppression rather than a migration.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    config->setFlag(nvinfer1::BuilderFlag::kFP16);
+#pragma GCC diagnostic pop
+    std::cout << "[TensorRT] FP16 mode enabled" << std::endl;
 #else
     if (builder->platformHasFastFp16()) {
         config->setFlag(nvinfer1::BuilderFlag::kFP16);
@@ -254,7 +268,7 @@ void TensorRTBackend::serialize_engine(const std::filesystem::path &engine_path)
         throw std::runtime_error("Failed to open file for writing: " + engine_path.string());
     }
 
-    file.write(static_cast<const char *>(serialized->data()), serialized->size());
+    file.write(static_cast<const char *>(serialized->data()), static_cast<std::streamsize>(serialized->size()));
 }
 
 bool TensorRTBackend::deserialize_engine(const std::filesystem::path &engine_path) {
@@ -264,11 +278,16 @@ bool TensorRTBackend::deserialize_engine(const std::filesystem::path &engine_pat
         return false;
     }
 
-    const size_t size = file.tellg();
+    const std::streamoff end = file.tellg();
+    if (end < 0) {
+        std::cerr << "Failed to determine engine file size: " << engine_path << std::endl;
+        return false;
+    }
+    const size_t size = static_cast<size_t>(end);
     file.seekg(0, std::ios::beg);
 
     std::vector<char> buffer(size);
-    if (!file.read(buffer.data(), size)) {
+    if (!file.read(buffer.data(), static_cast<std::streamsize>(size))) {
         std::cerr << "Failed to read engine file" << std::endl;
         return false;
     }


### PR DESCRIPTION
src/backends/tensorrt_backend.cpp and src/gpu/ were never compiled by CI. The first build of them happened on a rented GPU box, on the metered clock, and it failed before running a single kernel: eight -Werror errors, none of which needed a GPU to catch. They needed headers.

gpu-compile.yml stages headers-only TensorRT and DALI prefixes and builds the static library target with -DWERROR=ON across all four USE_DALI / USE_CUDA_POSTPROCESS combinations, since the two GPU halves are independent options and each combination is a distinct set of #if branches. It does not link and does not run: the staged shared objects are empty stubs, present only because the dependency resolver checks that the files exist. This is a compile gate, not a verification gate -- gpu-verify still owns behaviour, and roadmap Phase 2 still gates Phase 4.

The staging script assembles each prefix from the smallest artifact carrying the pinned headers: the libnvinfer-headers-dev / libnvonnxparsers-dev debs (~130 KB, unpacked with dpkg-deb -x so the 2 GB libnvinfer10 runtime is never pulled in), and include/ out of the DALI wheel -- the same tree fetch_dali.sh takes from the Triton container. The real distributions are 6.2 GB and 380 MB.

The fixes themselves:

- Binding and output volumes cast to size_t explicitly; serialize_engine and deserialize_engine cast to std::streamsize, and deserialize_engine now rejects a negative tellg() instead of converting it into a huge allocation.
- kEXPLICIT_BATCH is skipped on TensorRT 10, where explicit batch is the only mode and createNetworkV2 takes no flag.
- platformHasFastFp16() is dropped there too -- every GPU TensorRT 10 supports has fast FP16. BuilderFlag::kFP16 keeps a localized deprecation suppression: it is deprecated in favour of strongly-typed networks, but this build is deliberately weakly typed so an FP32 ONNX still gets FP16 kernels, and the flag is the only way to ask for that. Migrating would silently cost FP16.
- build_engine_from_onnx marks input_shape unused, matching the file's idiom.

Verified by compiling all three affected translation units against real TensorRT 10.13.3.9 headers under the full strict-warning set.


Claude-Session: https://claude.ai/code/session_01Qn7eRowTx4umR2WMAdKKz2