### PR TITLE
fix: close three ways versions.env could be the source of truth in na…

### DIFF
--- a/.github/workflows/gpu-compile.yml
+++ b/.github/workflows/gpu-compile.yml
@@ -53,13 +53,21 @@ jobs:
       - name: Stage TensorRT and DALI headers
         run: ./scripts/ci/stage_gpu_headers.sh
 
+      # The toolkit must be the one versions.env pins, since stage_gpu_headers.sh
+      # derives the TensorRT package coordinates (…-1+cuda<v>) from the same value.
+      # Hardcoding it here would let a CUDA_VERSION bump compile the newly pinned
+      # TensorRT headers against the old toolkit.
       - name: Install nvcc and the CUDA runtime headers
         run: |
+          source scripts/versions.sh
+          apt_suffix="${CUDA_VERSION//./-}"        # 13.0 -> 13-0
+          echo "Installing CUDA ${CUDA_VERSION} (apt suffix ${apt_suffix})"
           curl -fsSLO https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cuda-nvcc-13-0 cuda-cudart-dev-13-0
-          echo "/usr/local/cuda-13.0/bin" >> "$GITHUB_PATH"
+          sudo apt-get install -y --no-install-recommends \
+            "cuda-nvcc-${apt_suffix}" "cuda-cudart-dev-${apt_suffix}"
+          echo "/usr/local/cuda-${CUDA_VERSION}/bin" >> "$GITHUB_PATH"
 
       - name: Configure
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All of them now live in [`versions.env`](versions.env), and two loaders feed the
 | Loader | Consumers |
 |--------|-----------|
 | `cmake/versions.cmake` | Included by `CMakeLists.txt` before `cmake/deps/Deps.cmake`, so every `cmake/deps/packages/*.cmake` interpolates the values. Each pin is a `CACHE STRING` — `-DTENSORRT_VERSION=…` still overrides it |
-| `scripts/versions.sh` | `source`d by `fetch_dali.sh`, `generate_dali_pipelines.sh`, `ci/stage_gpu_headers.sh`, `run_gate.sh` and `export_trt.sh`. Never clobbers a value already in the environment, so the documented `TRITON_IMAGE=… ./scripts/fetch_dali.sh` overrides are unchanged |
+| `scripts/versions.sh` | `source`d by `fetch_dali.sh`, `generate_dali_pipelines.sh`, `ci/stage_gpu_headers.sh`, `run_gate.sh`, `export_trt.sh` and `gpu-compile.yml`. Never clobbers a value already in the environment, so the documented `TRITON_IMAGE=… ./scripts/fetch_dali.sh` overrides are unchanged |
 
 Coordinates that are truncations of another pin are *derived*, not stored, so a TensorRT
 bump stays one line. `TENSORRT_SHORT_VERSION` (`10.13.3`, the download-URL directory and
@@ -41,7 +41,25 @@ Dockerfile additionally gained `TENSORRT_VERSION`, `NGC_CONTAINER_TAG` and
 With the versions moved out of that script, a bump would have silently reused stale
 headers, so the key now covers `versions.env` and `scripts/versions.sh` too.
 
-`scripts/run_gate.sh` was a consumer that the first pass missed. Its `probe_dali` scraped
+Four defects found in review, each a way the "single source of truth" could have been true
+on paper and false in practice:
+
+- **Stale CMake cache.** A plain `set(… CACHE STRING …)` never overwrites an existing entry,
+  so editing `versions.env` in an existing build tree reconfigured (`CMAKE_CONFIGURE_DEPENDS`
+  saw the change) and still built the *old* version. Every pin now also records the
+  `versions.env` value it was configured from in an INTERNAL stamp: cache equal to stamp means
+  the value is still the file default and the new one is adopted; cache different means someone
+  passed `-D` and it is left alone.
+- **Dockerfile build arg only half-wired.** `--build-arg TENSORRT_VERSION` moved the shim
+  directory but was never passed to CMake, which kept reading the `versions.env` default, missed
+  the shim, and would have downloaded a different TensorRT than the NGC image provides. The
+  `cmake` invocation now receives `-DTENSORRT_VERSION`.
+- **CI CUDA toolkit hardcoded.** `gpu-compile.yml` installed `cuda-nvcc-13-0` /
+  `cuda-cudart-dev-13-0` literally while `stage_gpu_headers.sh` derived the TensorRT package
+  coordinates from `CUDA_VERSION`, so a bump would have compiled the new TensorRT headers
+  against the old toolkit. The workflow now derives the apt suffix and the `PATH` entry from
+  the pin.
+- **GPU gate provenance.** `scripts/run_gate.sh` was a consumer that the first pass missed. Its `probe_dali` scraped
 `fetch_dali.sh` with `sed` for the `${TRITON_IMAGE:-…}` assignment this change removed, so the
 GPU gate's `environment.txt` would have recorded an empty `extracted from:` field and lost the
 DALI provenance its verification record depends on. It now sources `versions.sh` like the

--- a/Dockerfile
+++ b/Dockerfile
@@ -164,10 +164,15 @@ RUN if [ "$INFERENCE_BACKEND" = "tensorrt" ]; then \
     fi
 
 
+# -DTENSORRT_VERSION must match the shim directory created above: with a
+# --build-arg override the shim moves, and without this CMake would keep reading
+# the versions.env default, miss the shim, and try to download that version
+# instead — mixing it with the NGC image's actual runtime.
 RUN CUDA_INC=""; \
     if [ "$INFERENCE_BACKEND" = "tensorrt" ]; then CUDA_INC="-I/usr/local/cuda/include"; fi; \
     cmake -S . -B build -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
+        -DTENSORRT_VERSION="$TENSORRT_VERSION" \
         -DCMAKE_C_COMPILER=/usr/bin/clang-18 \
         -DCMAKE_CXX_COMPILER=/usr/bin/clang++-18 \
         -DCMAKE_C_FLAGS="$CUDA_INC" \

--- a/cmake/versions.cmake
+++ b/cmake/versions.cmake
@@ -47,11 +47,37 @@ endfunction()
 # Publish one parsed key as a cache variable. Fails loudly rather than silently
 # expanding to the empty string, which would produce a plausible-looking but
 # wrong download URL.
+#
+# A plain `set(... CACHE STRING ...)` will not do here: it never overwrites an
+# existing cache entry, so editing versions.env in an *existing* build tree would
+# reconfigure (CMAKE_CONFIGURE_DEPENDS sees the file change) and still build the
+# old version — the source of truth defeated, silently, for everyone who does not
+# wipe their build directory.
+#
+# So each pin also records the versions.env value it was configured from, in an
+# INTERNAL stamp. On reconfigure:
+#   cache == stamp   the value is still the file-derived default and the file has
+#                    moved on -> adopt the new one.
+#   cache != stamp   somebody passed -D<name>=... -> never clobber it.
+# On a first configure there is no stamp, and the non-FORCE set already does the
+# right thing: honour -D if present, otherwise take the file value.
 macro(rfdetr_declare_version name doc)
     if(NOT DEFINED _RFDETR_ENV_${name})
         message(FATAL_ERROR "${name} is missing from ${RFDETR_VERSIONS_ENV}")
     endif()
-    set(${name} "${_RFDETR_ENV_${name}}" CACHE STRING "${doc}")
+    set(_rfdetr_default "${_RFDETR_ENV_${name}}")
+
+    if(DEFINED _RFDETR_STAMP_${name} AND DEFINED ${name}
+       AND "${${name}}" STREQUAL "${_RFDETR_STAMP_${name}}"
+       AND NOT "${${name}}" STREQUAL "${_rfdetr_default}")
+        set(${name} "${_rfdetr_default}" CACHE STRING "${doc}" FORCE)
+        message(STATUS "  ${name}: ${_RFDETR_STAMP_${name}} -> ${_rfdetr_default} (versions.env changed)")
+    else()
+        set(${name} "${_rfdetr_default}" CACHE STRING "${doc}")
+    endif()
+
+    set(_RFDETR_STAMP_${name} "${_rfdetr_default}" CACHE INTERNAL
+        "versions.env value ${name} was last configured from")
 endmacro()
 
 _rfdetr_read_versions_env("${RFDETR_VERSIONS_ENV}")

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -8,8 +8,8 @@ Two loaders read that file:
 
 | Loader | Consumers |
 |--------|-----------|
-| `cmake/versions.cmake` | Included by `CMakeLists.txt` before `cmake/deps/Deps.cmake`, so every `cmake/deps/packages/*.cmake` interpolates the values. Each pin is a `CACHE STRING`, so `-DTENSORRT_VERSION=…` overrides it |
-| `scripts/versions.sh` | `source`d by `scripts/fetch_dali.sh`, `scripts/generate_dali_pipelines.sh`, `scripts/ci/stage_gpu_headers.sh`, `scripts/run_gate.sh` (for the `environment.txt` provenance record) and `export_trt.sh`. Never clobbers a value already in the environment, so `TRITON_IMAGE=… ./scripts/fetch_dali.sh` still works |
+| `cmake/versions.cmake` | Included by `CMakeLists.txt` before `cmake/deps/Deps.cmake`, so every `cmake/deps/packages/*.cmake` interpolates the values. Each pin is a `CACHE STRING`, so `-DTENSORRT_VERSION=…` overrides it. Editing `versions.env` in an **existing** build tree updates the cache on reconfigure — an INTERNAL stamp per pin distinguishes "still the file default" from "overridden with `-D`", so no build directory wipe is needed and no `-D` is clobbered |
+| `scripts/versions.sh` | `source`d by `scripts/fetch_dali.sh`, `scripts/generate_dali_pipelines.sh`, `scripts/ci/stage_gpu_headers.sh`, `scripts/run_gate.sh` (for the `environment.txt` provenance record), `export_trt.sh`, and `gpu-compile.yml` (to derive the CUDA apt coordinates). Never clobbers a value already in the environment, so `TRITON_IMAGE=… ./scripts/fetch_dali.sh` still works |
 
 Four formats cannot read a file — the Dockerfile's `ARG` defaults, `conanfile.txt`,
 `deploy/requirements.txt`, and the argparse defaults in `deploy/export_*.py`. They restate the
@@ -124,6 +124,7 @@ Both push/PR workflows trigger on `master` and `develop`. Integration tests are 
   `docs/architecture.md` and `docs/package-manager-architecture.md` restate `versions.env` for
   readers. `AGENTS.md` requires them, and nothing verifies them — step 3 above is manual.
 - `project()` declares **no version**. `vcpkg.json` says `0.1.0`; the README badge says `0.4.0`. They disagree. This is a *project* version, not a dependency pin, so `versions.env` does not cover it.
+- The `Dockerfile` forwards `--build-arg TENSORRT_VERSION` to CMake as `-DTENSORRT_VERSION`, because the TensorRT shim directory it creates must match what CMake looks for. Any future build arg that names a pin needs the same forwarding.
 - `scripts/run_gate.sh` defaults `CUDA_ARCH=89` rather than the build default
   `CUDA_ARCHITECTURES=86`. Deliberate, and not a pin: the value is a property of whichever
   card the gate runs on, so it stays out of `versions.env`. `docs/rented-gpu-runbook.md`


### PR DESCRIPTION
…me only

All three found in review on PR #11, all three verified to reproduce before fixing.

Stale CMake cache. `set(... CACHE STRING ...)` never overwrites an existing entry, so editing versions.env in an existing build tree reconfigured -- CMAKE_CONFIGURE_DEPENDS saw the file change -- and still configured and built the old version. Demonstrated: versions.env reading 1.22.0 while the build reported and used 1.21.0. Every developer and CI job would have had to wipe their build directory for a bump to take effect.

Each pin now also records the versions.env value it was configured from, in an INTERNAL stamp. On reconfigure, cache == stamp means the entry still holds the file-derived default and the new value is adopted; cache != stamp means someone passed -D and it is left untouched. First configure keeps the non-FORCE set, so -D on a fresh tree still wins. Verified across six cases: fresh, file bump, file revert, -D on fresh, -D surviving a file bump, -D surviving a plain reconfigure.

Dockerfile build arg only half-wired. --build-arg TENSORRT_VERSION moved the system-library shim directory but was never passed to CMake, which kept reading the versions.env default, missed the shim, and would have downloaded that version instead -- mixing it with the NGC image's actual runtime. The cmake invocation now receives -DTENSORRT_VERSION.

CI CUDA toolkit hardcoded. gpu-compile.yml installed cuda-nvcc-13-0 and cuda-cudart-dev-13-0 literally and put /usr/local/cuda-13.0/bin on PATH, while stage_gpu_headers.sh derives the TensorRT package coordinates from CUDA_VERSION. A CUDA bump would have compiled the newly pinned TensorRT headers against the old toolkit, with check_version_sync.sh reporting success. The workflow now sources versions.sh and derives both the apt suffix (13.0 -> 13-0) and the PATH entry; the derivation reproduces today's package names exactly, so nothing changes until the pin does.

Reported by codex review on PR #11.


Claude-Session: https://claude.ai/code/session_01WZxpcYtA6WRz7Z8nQNLAna